### PR TITLE
feat: genome alignment tool — full implementation + redesign

### DIFF
--- a/docs/specs/2026-05-28-genome-alignment-design.md
+++ b/docs/specs/2026-05-28-genome-alignment-design.md
@@ -1,0 +1,162 @@
+# Genome Alignment Tool — Design Spec
+**Date:** 2026-05-28  
+**Status:** Approved, ready for implementation
+
+---
+
+## Overview
+
+A synteny viewer comparing two Chlamydia genomes side-by-side, added as a third entry in the Tools dropdown. Named "Genome Alignment" to match the existing "Sequence Alignment" and "Structure Alignment" tools. The tool emphasizes the strong synteny shared across Chlamydia species while making divergence (absent orthologs, rearrangements) immediately visible.
+
+---
+
+## Goals
+
+- Let users scroll through the full chromosome of any two strains, seeing ortholog pairs connected by ribbons and gaps where orthologs are absent
+- Highlight functional category clusters visually (T3SS block, Inc block, Translation block, etc.) so blocks of conserved function stand out at a glance
+- Provide low-friction navigation for 1,100+ gene genomes without requiring users to know a specific region of interest
+- Field-first for the Chlamydia community; especially valuable when Cpn is added as a fourth strain
+
+---
+
+## Out of Scope (this version)
+
+- % identity calculation (Needleman-Wunsch or otherwise) — deferred to v2
+- Virtual scrolling — paginated DOM append is sufficient
+- Same-strain comparison
+- Plasmid genes (excluded; chromosome only)
+- Mobile layout (deferred to the broader mobile pass)
+
+---
+
+## Architecture
+
+### New file
+`web/js/views/genome-alignment.js` — module pattern identical to `alignment.js` and `structure-alignment.js`.
+
+### Registration
+- Added to `TABS` array in `app.js` as `'genome-alignment'`
+- Added to `RENDERERS` map as `renderGenomeAlignment`
+- Added to `showToolsPopover()` in `app.js` as a third entry in the Tools dropdown
+
+### Data flow
+
+1. **On mount:** Fetch all strains from `strains` table → populate Reference and Comparison pickers
+2. **On strain pair selection:** 
+   - Fetch all chromosome genes for the reference strain: `genes` table filtered by `strain_id`, `sort_index < 871`, ordered by `sort_index`. Store as `_refGenes[]`.
+   - Fetch all chromosome genes for the comparison strain: same query. Store as `_cmpGenes[]`.
+   - Fetch all ortholog pairs linking the two strain IDs from `orthologs` table. Build `Map<refGeneId, cmpGeneId>` for O(1) lookup.
+3. **Render first page** (100 reference genes), then use `IntersectionObserver` on a sentinel element at the bottom to load the next page as the user scrolls.
+
+### Pagination
+- Page size: 100 reference genes
+- Each page: slice `_refGenes`, resolve comparison ortholog for each via the Map, append rows to DOM, add SVG path elements to the ribbon SVG
+- No "load more" button — scroll-triggered via `IntersectionObserver`
+
+---
+
+## UI Layout
+
+### Top bar (sticky, two rows)
+
+**Row 1 — Strain pickers + search:**
+```
+[ 🔵 CT L2/434 ▼ ]  ⇄  [ Comparison genome ▼ ]      [ 🔍 Search gene… ]
+```
+- Strain pickers show strain icon + common name, styled with strain color border (matching existing strain color system)
+- The ⇄ icon between pickers is non-interactive (not a swap button)
+- Search box: filters reference gene list by `locus_tag` or `gene_name`, scrolls to and highlights first match
+
+**Row 2 — Jump chips:**
+```
+JUMP TO: [CTL0001] [CTL0100] [CTL0200] … [CTL0870 (end)]
+```
+- Chips generated dynamically from `_refGenes` at every 100th gene by `sort_index`
+- Clicking a chip synchronously renders all intermediate pages up to that position, then scrolls to the target row
+- Last chip always shows the final gene (labeled with locus tag + "(end)")
+
+**Row 3 — Category legend:**
+- Colored swatches + `FUNC_LABELS` abbreviations for all 17 categories
+- Reuses `CATEGORY_COLORS` and `FUNC_LABELS` from `genomes.js` (copy constants into new file)
+
+### Three-column body
+
+| Column | Width | Content |
+|--------|-------|---------|
+| Reference | 38% | Gene rows, left-anchored |
+| Ribbon | 24% | SVG, absolutely positioned, grows with list |
+| Comparison | 38% | Gene rows, left-anchored |
+
+### Gene rows
+
+- Height: ~20px (compact)
+- Font: monospace for locus tags
+- Left border: 4px solid, color = `CATEGORY_COLORS[functional_category]` (default `#E5E7EB`)
+- Background tint: category color at ~6% opacity
+- Named/characterized genes: slightly bolder weight, colored text matching category
+- Uncharacterized genes: muted gray text
+
+**Comparison-side ortholog rows** use the *same* functional category color as their reference counterpart (same gene, same function).
+
+**Gap rows** (no ortholog in comparison genome):
+- Reference side: renders normally
+- Center: faint ✕ circle at midpoint
+- Comparison side: `— no ortholog —` in light gray italic, no border, no background tint
+
+### Ribbon (SVG)
+
+- One `<path>` per ortholog pair: cubic bezier from ref row midpoint to cmp row midpoint
+- Stroke color: `CATEGORY_COLORS[functional_category]` at ~55% opacity
+- Stroke width: 7–9px (named genes slightly wider than uncharacterized)
+- Gap indicator: small circle (radius 5px) at center x, filled light red (`#fca5a5`)
+- SVG is in-flow inside the center column div; its `height` attribute is updated on each page append to match the total rendered list height
+- Rearrangements (crossing ribbons) are intentional signal — no special handling
+
+### Expand-on-click
+
+Clicking any gene row expands that pair in place (both reference and comparison sides expand together):
+- Full gene name
+- Product description
+- Functional category badge (uses existing `CATEGORY_BADGE` styles from `genomes.js`)
+- `→ Gene detail` link (navigates to gene detail in the Genomes tab)
+- Ribbon highlights that pair's connector (increased stroke width + opacity)
+- Clicking again collapses
+
+Only one pair expanded at a time — expanding a new row collapses the previous one.
+
+---
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| No strains selected | Centered empty state: "Select two genomes above to begin." |
+| Same strain on both sides | Inline warning below pickers: "Select two different genomes." No load. |
+| Reference gene has no ortholog | Gap row on comparison side, ✕ in ribbon |
+| Comparison gene not in reference | Not shown (tool is anchored to reference sort_index order) |
+| Rearrangement (out-of-order ortholog) | Crossing ribbon lines — intentional, no special handling |
+| Supabase load error | Error banner below top bar with retry button |
+| Plasmid genes (sort_index ≥ 871) | Excluded from both sides; small footer note: "Plasmid genes excluded." |
+
+---
+
+## Reused Patterns & Assets
+
+| Resource | Source | Usage |
+|----------|--------|-------|
+| `CATEGORY_COLORS` | `genomes.js` | Row border, background tint, ribbon stroke |
+| `CATEGORY_BADGE` | `genomes.js` | Expanded row badge style |
+| `FUNC_LABELS` | `genomes.js` | Category legend abbreviations |
+| Strain icons + colors | `genomes.js` / `strains` table | Strain picker display |
+| `openNavPopover()` / Tools dropdown | `app.js` | Add third Tools entry |
+| `activateTab()` | `app.js` | Navigation |
+| Error banner pattern | Existing views | Load failure UI |
+
+---
+
+## Future Work (explicitly deferred)
+
+- **% identity:** Client-side Needleman-Wunsch on AA sequences, computed on expand. Requires `proteins.aa_sequence` join. Shown as a colored chip in the expanded row (green ≥ 90%, yellow 70–89%, red < 70%).
+- **Virtual scrolling:** Replace paginated DOM append if performance degrades with Cpn (~1,000 additional genes).
+- **Mobile layout:** Part of the broader mobile design pass (backlog item #12).
+- **Download / export:** TSV export of the ortholog comparison table.

--- a/docs/specs/2026-05-28-genome-alignment-plan.md
+++ b/docs/specs/2026-05-28-genome-alignment-plan.md
@@ -1,0 +1,1060 @@
+# Genome Alignment Tool Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a side-by-side synteny viewer comparing two Chlamydia chromosome genomes, added as a third entry in the Tools dropdown menu.
+
+**Architecture:** A new `genome-alignment.js` view module loads both genomes' genes and their ortholog pairs from Supabase on strain selection, then renders paginated 100-gene pages into a three-column flex layout (reference genes | SVG ribbon | comparison genes), using IntersectionObserver to load the next page automatically on scroll.
+
+**Tech Stack:** Vanilla JS ES modules, Supabase JS client (`sb` from `client.js`), inline SVG for ribbons, same module/import pattern as `alignment.js` and `structure-alignment.js`.
+
+---
+
+## Background: Codebase Conventions
+
+- **Imports** use cache-bust version strings: `import { renderFoo } from './views/foo.js?v=1';`
+- **Tab system:** `TABS` array + `RENDERERS` map in `app.js`. Each tab needs a `<section id="tab-{name}">` + `<div id="{name}-content">` in `index.html`. `activateTab(name)` clears the container and calls the renderer.
+- **Supabase:** `sb` is the Supabase JS client. Queries follow `sb.from('table').select('cols').eq('col', val)`.
+- **Strain IDs:** Strains are identified by UUID in the database (`strain_id` column on `genes`, `strain_id_a`/`strain_id_b` on `orthologs`). The `strains` table has `id` (UUID), `common_name` (e.g. "CT-L2"), `color_hex`, `emoji_icon`.
+- **Gene sort order:** `sort_index` is the chromosome position integer. Chromosome genes: `sort_index < 871`. Plasmid genes: `sort_index >= 871` — exclude from this tool.
+- **Orthologs table columns:** `gene_id_a`, `gene_id_b`, `strain_id_a`, `strain_id_b`. A pair may be stored in either direction.
+- **Functional categories:** 17 categories, each with a hex color. The constants `CATEGORY_COLORS`, `CATEGORY_BADGE`, `FUNC_LABELS` in `genomes.js` are the source of truth — copy them into the new file.
+- **Gene detail navigation:** `window.__openGeneId = geneId; activateTab('genomes');` opens gene detail.
+
+---
+
+## File Map
+
+| Action | File | What changes |
+|--------|------|-------------|
+| Create | `web/js/views/genome-alignment.js` | Entire new view module |
+| Modify | `web/js/app.js` | Import, TABS, RENDERERS, Tools dropdown, active state |
+| Modify | `web/index.html` | New `<section>` + `<div>` for the tab |
+
+---
+
+## Task 1: Register the tab in app.js and index.html
+
+**Files:**
+- Modify: `web/js/app.js:1–61, 77–97`
+- Modify: `web/index.html` (after line 138, before `</main>`)
+
+- [ ] **Step 1: Add the import to app.js**
+
+At line 9, after the `renderStructureAlignment` import, add:
+
+```js
+import { renderGenomeAlignment } from './views/genome-alignment.js?v=1';
+```
+
+- [ ] **Step 2: Add genome-alignment to TABS and RENDERERS in app.js**
+
+Replace the TABS line (line 52) and RENDERERS block (lines 53–61):
+
+```js
+const TABS = ['home', 'genomes', 'mutants', 'pipeline', 'roadmap', 'alignment', 'structure-alignment', 'genome-alignment'];
+const RENDERERS = {
+  home:      renderHome,
+  genomes:   renderGenomes,
+  mutants:   renderMutants,
+  pipeline:  renderPipeline,
+  roadmap:   renderRoadmap,
+  alignment: renderAlignment,
+  'structure-alignment': renderStructureAlignment,
+  'genome-alignment':    renderGenomeAlignment,
+};
+```
+
+- [ ] **Step 3: Add genome-alignment to the Tools active state check in app.js**
+
+Replace line 85:
+```js
+  if (toolsBtn) toolsBtn.classList.toggle('active', name === 'alignment' || name === 'structure-alignment' || name === 'genome-alignment');
+```
+
+- [ ] **Step 4: Add genome-alignment to showToolsPopover() in app.js**
+
+Add a genome icon and a third button inside `showToolsPopover()`. Replace the entire function (lines 27–49):
+
+```js
+function showToolsPopover(anchor) {
+  const seqIcon = `<svg width="15" height="15" viewBox="0 0 15 15" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" style="display:block;flex-shrink:0;opacity:0.7"><line x1="1" y1="4" x2="11" y2="4"/><line x1="4" y1="7.5" x2="14" y2="7.5"/><line x1="2" y1="11" x2="12" y2="11"/></svg>`;
+  const structIcon = `<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="display:block;flex-shrink:0;opacity:0.7"><path d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9"/></svg>`;
+  const genomeIcon = `<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="display:block;flex-shrink:0;opacity:0.7"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>`;
+  const pop = openNavPopover(anchor, `
+    <div class="nav-popover-label">Tools</div>
+    <button class="nav-popover-row" id="tools-pop-seq">
+      <span class="nav-popover-row-icon">${seqIcon}</span>
+      <span class="nav-popover-row-name">Sequence Alignment</span>
+    </button>
+    <button class="nav-popover-row" id="tools-pop-struct">
+      <span class="nav-popover-row-icon">${structIcon}</span>
+      <span class="nav-popover-row-name">Structure Alignment</span>
+    </button>
+    <button class="nav-popover-row" id="tools-pop-genome">
+      <span class="nav-popover-row-icon">${genomeIcon}</span>
+      <span class="nav-popover-row-name">Genome Alignment</span>
+    </button>
+  `, 'tools-nav-popover');
+  pop?.querySelector('#tools-pop-seq')?.addEventListener('click', () => {
+    pop.remove();
+    activateTab('alignment');
+  });
+  pop?.querySelector('#tools-pop-struct')?.addEventListener('click', () => {
+    pop.remove();
+    activateTab('structure-alignment');
+  });
+  pop?.querySelector('#tools-pop-genome')?.addEventListener('click', () => {
+    pop.remove();
+    activateTab('genome-alignment');
+  });
+}
+```
+
+- [ ] **Step 5: Add the tab section to index.html**
+
+After line 138 (after the `</section>` that closes `tab-structure-alignment`), add:
+
+```html
+    <!-- GENOME ALIGNMENT TAB -->
+    <section id="tab-genome-alignment" class="tab-panel hidden">
+      <div id="genome-alignment-content"></div>
+    </section>
+```
+
+- [ ] **Step 6: Create an empty stub for the new view so the import doesn't break**
+
+Create `web/js/views/genome-alignment.js` with just the export:
+
+```js
+// ChlamAtlas — Genome Alignment tool
+import { sb } from '../client.js?v=80';
+
+export function renderGenomeAlignment(container) {
+  container.innerHTML = '<p style="padding:24px;color:#6b7280;">Loading…</p>';
+}
+```
+
+- [ ] **Step 7: Verify in browser**
+
+Open the site, click Tools. Confirm "Genome Alignment" appears as a third menu item. Click it — the tab should activate and show "Loading…". The URL hash should change to `#/genome-alignment`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/js/app.js web/index.html web/js/views/genome-alignment.js
+git commit -m "feat: register genome-alignment tab and Tools menu entry"
+```
+
+---
+
+## Task 2: Scaffold the view — constants, module state, container HTML, load strains
+
+**Files:**
+- Modify: `web/js/views/genome-alignment.js` (full rewrite of the stub)
+
+- [ ] **Step 1: Write the full scaffold with constants, state, and container HTML**
+
+Replace the entire file:
+
+```js
+// ChlamAtlas — Genome Alignment tool
+import { sb } from '../client.js?v=80';
+
+// ── Constants (copied from genomes.js) ───────────────────────
+const CATEGORY_COLORS = {
+  'Amino acid metabolism':      '#E66729',
+  'Cell envelope':              '#00A69D',
+  'Cell processes':             '#0052A3',
+  'Cofactor metabolism':        '#838FC7',
+  'Energy metabolism':          '#EC1C24',
+  'Inclusion membrane protein': '#E4B47E',
+  'Inermediary metabolism':     '#9D270E',
+  'Lipid metabolism':           '#6F2D90',
+  'Membrane transport':         '#6DCFF5',
+  'Nucleotide metabolism':      '#F497AE',
+  'Other':                      '#EBEBEB',
+  'Replication':                '#FFF100',
+  'Secreted effector':          '#00A551',
+  'Transcription':              '#FCB814',
+  'Translation':                '#BED630',
+  'Type III secretion':         '#8A5D3B',
+  'Unknown':                    '#AAAAAA',
+};
+const CATEGORY_COLOR_DEFAULT = '#E5E7EB';
+
+const CATEGORY_BADGE = {
+  'Amino acid metabolism':      { bg:'#fff3ed', text:'#9a3412', border:'#fed7aa' },
+  'Cell envelope':              { bg:'#f0fdfa', text:'#134e4a', border:'#99f6e4' },
+  'Cell processes':             { bg:'#eff6ff', text:'#1e3a8a', border:'#bfdbfe' },
+  'Cofactor metabolism':        { bg:'#f5f3ff', text:'#4c1d95', border:'#ddd6fe' },
+  'Energy metabolism':          { bg:'#fef2f2', text:'#991b1b', border:'#fecaca' },
+  'Inclusion membrane protein': { bg:'#fef9ee', text:'#a37742', border:'#f0d898' },
+  'Inermediary metabolism':     { bg:'#fef2f2', text:'#7f1d1d', border:'#fecaca' },
+  'Lipid metabolism':           { bg:'#faf5ff', text:'#581c87', border:'#e9d5ff' },
+  'Membrane transport':         { bg:'#f0f9ff', text:'#0c4a6e', border:'#bae6fd' },
+  'Nucleotide metabolism':      { bg:'#fdf2f8', text:'#831843', border:'#fbcfe8' },
+  'Other':                      { bg:'#f9fafb', text:'#6b7280', border:'#e5e7eb' },
+  'Replication':                { bg:'#fefce8', text:'#713f12', border:'#fde68a' },
+  'Secreted effector':          { bg:'#f0fdf4', text:'#14532d', border:'#86efac' },
+  'Transcription':              { bg:'#fffbeb', text:'#78350f', border:'#fde68a' },
+  'Translation':                { bg:'#f7fee7', text:'#365314', border:'#d9f99d' },
+  'Type III secretion':         { bg:'#fdf4ef', text:'#5c3317', border:'#e8c9b3' },
+  'Unknown':                    { bg:'#f9fafb', text:'#6b7280', border:'#e5e7eb' },
+};
+
+const FUNC_LABELS = {
+  'Amino acid metabolism':      'Amino acid',
+  'Cell envelope':              'Cell envelope',
+  'Cell processes':             'Cell processes',
+  'Cofactor metabolism':        'Cofactor',
+  'Energy metabolism':          'Energy',
+  'Inclusion membrane protein': 'Inc',
+  'Inermediary metabolism':     'Intermediary',
+  'Lipid metabolism':           'Lipid',
+  'Membrane transport':         'Transport',
+  'Nucleotide metabolism':      'Nucleotide',
+  'Other':                      'Other',
+  'Replication':                'Replication',
+  'Secreted effector':          'Secreted effector',
+  'Transcription':              'Transcription',
+  'Translation':                'Translation',
+  'Type III secretion':         'T3SS',
+  'Unknown':                    'Unknown',
+};
+
+const ROW_HEIGHT = 22; // px — fixed row height for ribbon Y calculation
+const PAGE_SIZE  = 100;
+
+// ── Module state (reset on each renderGenomeAlignment call) ──
+let _strains      = [];        // [{id, common_name, color_hex, emoji_icon}, ...]
+let _refStrainId  = null;
+let _cmpStrainId  = null;
+let _refGenes     = [];        // ordered by sort_index
+let _cmpGenes     = [];
+let _orthologMap  = new Map(); // refGeneId → cmpGeneId
+let _cmpGeneMap   = new Map(); // cmpGeneId → gene object
+let _renderedCount = 0;
+let _expandedRefId = null;     // currently expanded reference gene id
+let _observer     = null;      // IntersectionObserver for pagination
+let _container    = null;      // root container div
+
+// ── Entry point ──────────────────────────────────────────────
+export async function renderGenomeAlignment(container) {
+  _container    = container;
+  _strains      = [];
+  _refStrainId  = null;
+  _cmpStrainId  = null;
+  _refGenes     = [];
+  _cmpGenes     = [];
+  _orthologMap  = new Map();
+  _cmpGeneMap   = new Map();
+  _renderedCount = 0;
+  _expandedRefId = null;
+  if (_observer) { _observer.disconnect(); _observer = null; }
+
+  container.innerHTML = `
+    <div id="ga-wrap" style="display:flex;flex-direction:column;height:calc(100vh - 56px);font-family:system-ui,sans-serif;">
+
+      <!-- Sticky top bar -->
+      <div id="ga-topbar" style="position:sticky;top:0;z-index:10;background:#fff;border-bottom:1px solid #e2e8f0;flex-shrink:0;">
+
+        <!-- Row 1: strain pickers + search -->
+        <div style="display:flex;align-items:center;gap:8px;padding:8px 12px;flex-wrap:wrap;">
+          <select id="ga-ref-picker" style="border:1.5px solid #3b82f6;border-radius:6px;padding:4px 8px;font-size:12px;font-weight:600;color:#1d4ed8;background:#fff;cursor:pointer;">
+            <option value="">Reference genome…</option>
+          </select>
+          <span style="color:#94a3b8;font-size:16px;flex-shrink:0;">⇄</span>
+          <select id="ga-cmp-picker" style="border:1.5px solid #d97706;border-radius:6px;padding:4px 8px;font-size:12px;font-weight:600;color:#b45309;background:#fff;cursor:pointer;">
+            <option value="">Comparison genome…</option>
+          </select>
+          <input id="ga-search" placeholder="🔍 Search gene…" style="margin-left:auto;border:1px solid #e2e8f0;border-radius:6px;padding:4px 10px;font-size:12px;color:#374151;width:180px;outline:none;">
+        </div>
+
+        <!-- Row 2: jump chips (populated after gene load) -->
+        <div id="ga-jump-row" style="display:none;align-items:center;gap:5px;padding:3px 12px 4px;flex-wrap:wrap;font-size:10px;">
+          <span style="color:#94a3b8;font-weight:700;flex-shrink:0;letter-spacing:0.05em;">JUMP TO:</span>
+          <div id="ga-jump-chips" style="display:flex;gap:4px;flex-wrap:wrap;"></div>
+        </div>
+
+        <!-- Row 3: category legend (populated after gene load) -->
+        <div id="ga-legend-row" style="display:none;align-items:center;gap:6px;padding:3px 12px 5px;flex-wrap:wrap;font-size:9px;"></div>
+
+        <!-- Warning banner (same strain) -->
+        <div id="ga-warning" style="display:none;padding:4px 12px;background:#fef9c3;color:#854d0e;font-size:11px;border-top:1px solid #fde68a;">
+          ⚠️ Select two different genomes to compare.
+        </div>
+
+        <!-- Error banner -->
+        <div id="ga-error" style="display:none;padding:6px 12px;background:#fef2f2;color:#991b1b;font-size:11px;border-top:1px solid #fecaca;">
+          Failed to load genome data.
+          <button id="ga-retry" style="margin-left:8px;font-size:11px;color:#1d4ed8;background:none;border:none;cursor:pointer;text-decoration:underline;">Retry</button>
+        </div>
+      </div>
+
+      <!-- Empty state -->
+      <div id="ga-empty" style="display:flex;align-items:center;justify-content:center;flex:1;color:#94a3b8;font-size:14px;">
+        Select two genomes above to begin.
+      </div>
+
+      <!-- Gene list (hidden until data loaded) -->
+      <div id="ga-list" style="display:none;flex:1;overflow-y:auto;">
+        <div id="ga-columns" style="display:flex;min-height:100%;">
+          <div id="ga-ref-col" style="width:38%;border-right:1px solid #f0f0f0;"></div>
+          <div id="ga-ribbon-col" style="width:24%;position:relative;overflow:visible;">
+            <svg id="ga-svg" width="100%" height="0"
+              viewBox="0 0 100 0"
+              preserveAspectRatio="none"
+              style="position:absolute;top:0;left:0;pointer-events:none;"></svg>
+          </div>
+          <div id="ga-cmp-col" style="width:38%;border-left:1px solid #f0f0f0;"></div>
+        </div>
+        <div id="ga-sentinel" style="height:1px;"></div>
+        <div id="ga-footer" style="display:none;padding:6px 12px;font-size:10px;color:#9ca3af;text-align:center;">
+          Plasmid genes excluded from this view.
+        </div>
+      </div>
+
+    </div>
+  `;
+
+  await loadStrains();
+}
+```
+
+- [ ] **Step 2: Implement loadStrains()**
+
+Append this function to the file:
+
+```js
+// ── Strain loading ───────────────────────────────────────────
+async function loadStrains() {
+  const { data, error } = await sb
+    .from('strains')
+    .select('id,common_name,color_hex,emoji_icon')
+    .eq('is_active', true)
+    .order('common_name');
+
+  if (error || !data?.length) {
+    showError(true);
+    return;
+  }
+
+  _strains = data;
+  const refPicker = _container.querySelector('#ga-ref-picker');
+  const cmpPicker = _container.querySelector('#ga-cmp-picker');
+
+  data.forEach(s => {
+    const label = `${s.emoji_icon ?? ''} ${s.common_name}`.trim();
+    refPicker.insertAdjacentHTML('beforeend',
+      `<option value="${s.id}">${label}</option>`);
+    cmpPicker.insertAdjacentHTML('beforeend',
+      `<option value="${s.id}">${label}</option>`);
+  });
+
+  refPicker.addEventListener('change', onPickerChange);
+  cmpPicker.addEventListener('change', onPickerChange);
+
+  _container.querySelector('#ga-retry')?.addEventListener('click', () => {
+    showError(false);
+    onPickerChange();
+  });
+  _container.querySelector('#ga-search')?.addEventListener('input', onSearch);
+}
+
+function showError(visible) {
+  _container.querySelector('#ga-error').style.display = visible ? 'block' : 'none';
+}
+
+function showWarning(visible) {
+  _container.querySelector('#ga-warning').style.display = visible ? 'block' : 'none';
+}
+```
+
+- [ ] **Step 3: Verify in browser**
+
+Open the site → Tools → Genome Alignment. Both dropdowns should populate with the three active strains. No errors in console.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/js/views/genome-alignment.js
+git commit -m "feat: genome alignment scaffold — container HTML, constants, strain pickers"
+```
+
+---
+
+## Task 3: Load genes and build ortholog map on strain selection
+
+**Files:**
+- Modify: `web/js/views/genome-alignment.js` (append functions)
+
+- [ ] **Step 1: Implement onPickerChange() — validates selection and kicks off data load**
+
+Append to the file:
+
+```js
+// ── Strain selection handler ──────────────────────────────────
+async function onPickerChange() {
+  const refId = _container.querySelector('#ga-ref-picker').value;
+  const cmpId = _container.querySelector('#ga-cmp-picker').value;
+
+  if (!refId || !cmpId) return;
+
+  if (refId === cmpId) {
+    showWarning(true);
+    return;
+  }
+  showWarning(false);
+
+  _refStrainId  = refId;
+  _cmpStrainId  = cmpId;
+  _renderedCount = 0;
+  _expandedRefId = null;
+  if (_observer) { _observer.disconnect(); _observer = null; }
+
+  // Reset list
+  _container.querySelector('#ga-ref-col').innerHTML  = '';
+  _container.querySelector('#ga-cmp-col').innerHTML  = '';
+  _container.querySelector('#ga-svg').innerHTML      = '';
+  _container.querySelector('#ga-svg').setAttribute('height', '0');
+  _container.querySelector('#ga-svg').setAttribute('viewBox', '0 0 100 0');
+  _container.querySelector('#ga-list').style.display = 'none';
+  _container.querySelector('#ga-empty').style.display = 'flex';
+  _container.querySelector('#ga-empty').textContent  = 'Loading…';
+  _container.querySelector('#ga-jump-row').style.display   = 'none';
+  _container.querySelector('#ga-legend-row').style.display = 'none';
+  _container.querySelector('#ga-footer').style.display     = 'none';
+  showError(false);
+
+  await loadGenes();
+}
+```
+
+- [ ] **Step 2: Implement loadGenes() — fetches both gene lists and the ortholog map**
+
+Append to the file:
+
+```js
+async function loadGenes() {
+  const GENE_COLS = 'id,locus_tag,gene_name,gene_symbol,product,functional_category,sort_index,is_characterized';
+
+  const [refRes, cmpRes] = await Promise.all([
+    sb.from('genes')
+      .select(GENE_COLS)
+      .eq('strain_id', _refStrainId)
+      .lt('sort_index', 871)
+      .order('sort_index'),
+    sb.from('genes')
+      .select(GENE_COLS)
+      .eq('strain_id', _cmpStrainId)
+      .lt('sort_index', 871)
+      .order('sort_index'),
+  ]);
+
+  if (refRes.error || cmpRes.error) {
+    showError(true);
+    _container.querySelector('#ga-empty').textContent = 'Select two genomes above to begin.';
+    return;
+  }
+
+  _refGenes = refRes.data ?? [];
+  _cmpGenes = cmpRes.data ?? [];
+
+  // Build cmpGeneMap for O(1) lookup
+  _cmpGeneMap = new Map(_cmpGenes.map(g => [g.id, g]));
+
+  // Fetch orthologs for this strain pair (both directions)
+  const [o1, o2] = await Promise.all([
+    sb.from('orthologs')
+      .select('gene_id_a,gene_id_b')
+      .eq('strain_id_a', _refStrainId)
+      .eq('strain_id_b', _cmpStrainId),
+    sb.from('orthologs')
+      .select('gene_id_a,gene_id_b')
+      .eq('strain_id_a', _cmpStrainId)
+      .eq('strain_id_b', _refStrainId),
+  ]);
+
+  _orthologMap = new Map();
+  const cmpIdSet = new Set(_cmpGenes.map(g => g.id));
+  const refIdSet = new Set(_refGenes.map(g => g.id));
+
+  for (const row of (o1.data ?? [])) {
+    if (refIdSet.has(row.gene_id_a) && cmpIdSet.has(row.gene_id_b)) {
+      _orthologMap.set(row.gene_id_a, row.gene_id_b);
+    }
+  }
+  for (const row of (o2.data ?? [])) {
+    if (refIdSet.has(row.gene_id_b) && cmpIdSet.has(row.gene_id_a)) {
+      _orthologMap.set(row.gene_id_b, row.gene_id_a);
+    }
+  }
+
+  // Ready to render
+  buildJumpChips();
+  buildLegend();
+  _container.querySelector('#ga-empty').style.display = 'none';
+  _container.querySelector('#ga-list').style.display  = 'block';
+  _container.querySelector('#ga-footer').style.display = 'block';
+  appendPage();
+  setupObserver();
+}
+```
+
+- [ ] **Step 3: Verify in browser**
+
+Select two strains. Open browser DevTools → Network. Confirm four Supabase queries fire (ref genes, cmp genes, orthologs direction 1, orthologs direction 2). No console errors. The empty state should change to "Loading…" then disappear. (The list area will be empty until Task 4 renders rows.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/js/views/genome-alignment.js
+git commit -m "feat: genome alignment — load genes and build ortholog map on strain selection"
+```
+
+---
+
+## Task 4: Render gene rows and SVG ribbon
+
+**Files:**
+- Modify: `web/js/views/genome-alignment.js` (append functions)
+
+- [ ] **Step 1: Implement appendPage() — renders the next 100 reference genes**
+
+Append to the file:
+
+```js
+// ── Rendering ────────────────────────────────────────────────
+function appendPage() {
+  const start = _renderedCount;
+  const end   = Math.min(start + PAGE_SIZE, _refGenes.length);
+  if (start >= _refGenes.length) return;
+
+  const refCol = _container.querySelector('#ga-ref-col');
+  const cmpCol = _container.querySelector('#ga-cmp-col');
+  const svgEl  = _container.querySelector('#ga-svg');
+
+  for (let i = start; i < end; i++) {
+    const refGene   = _refGenes[i];
+    const cmpGeneId = _orthologMap.get(refGene.id) ?? null;
+    const cmpGene   = cmpGeneId ? _cmpGeneMap.get(cmpGeneId) : null;
+    const catColor  = CATEGORY_COLORS[refGene.functional_category] ?? CATEGORY_COLOR_DEFAULT;
+
+    refCol.appendChild(buildRow(refGene, catColor, true));
+    cmpCol.appendChild(cmpGene ? buildRow(cmpGene, catColor, false, refGene.id) : buildGapRow());
+
+    const y = i * ROW_HEIGHT + ROW_HEIGHT / 2;
+    if (cmpGene) {
+      svgEl.insertAdjacentHTML('beforeend',
+        `<path data-ref-id="${refGene.id}" d="M 0,${y} C 50,${y} 50,${y} 100,${y}"` +
+        ` stroke="${catColor}" stroke-width="${refGene.gene_name ? 9 : 7}"` +
+        ` fill="none" opacity="0.55"/>`);
+    } else {
+      svgEl.insertAdjacentHTML('beforeend',
+        `<circle data-ref-id="${refGene.id}" cx="50" cy="${y}" r="4"` +
+        ` fill="#fca5a5" opacity="0.8"/>`);
+    }
+  }
+
+  _renderedCount = end;
+  const totalH = _renderedCount * ROW_HEIGHT;
+  svgEl.setAttribute('height', totalH);
+  svgEl.setAttribute('viewBox', `0 0 100 ${totalH}`);
+}
+```
+
+- [ ] **Step 2: Implement buildRow() — a single gene row div**
+
+Append to the file:
+
+```js
+function buildRow(gene, catColor, isRef, refId = null) {
+  const named = !!(gene.gene_name || gene.gene_symbol);
+  const displayName = gene.gene_name || gene.gene_symbol || '';
+  const locusTag = gene.locus_tag ?? '';
+  const r = parseInt(catColor.slice(1,3), 16);
+  const g = parseInt(catColor.slice(3,5), 16);
+  const b = parseInt(catColor.slice(5,7), 16);
+  const bgTint = `rgba(${r},${g},${b},0.06)`;
+
+  const row = document.createElement('div');
+  row.className = 'ga-row';
+  row.dataset.refId = isRef ? gene.id : (refId ?? gene.id);
+  row.dataset.geneId = gene.id;
+  row.style.cssText = [
+    `height:${ROW_HEIGHT}px`,
+    'overflow:hidden',
+    'cursor:pointer',
+    `border-left:4px solid ${catColor}`,
+    `background:${bgTint}`,
+    'display:flex',
+    'align-items:center',
+    'padding:0 6px 0 6px',
+    'gap:5px',
+    'box-sizing:border-box',
+    'position:relative',
+    'border-bottom:1px solid rgba(0,0,0,0.03)',
+  ].join(';');
+
+  const tagSpan = document.createElement('span');
+  tagSpan.style.cssText = 'font-family:monospace;font-size:10px;flex-shrink:0;color:' +
+    (named ? '#1a1a1a' : '#9ca3af');
+  tagSpan.textContent = locusTag;
+
+  row.appendChild(tagSpan);
+
+  if (named) {
+    const nameSpan = document.createElement('span');
+    nameSpan.style.cssText = `font-size:10px;font-weight:700;color:${catColor};flex-shrink:0;`;
+    nameSpan.textContent = '· ' + displayName;
+    row.appendChild(nameSpan);
+  }
+
+  row.addEventListener('click', () => toggleExpand(row, gene, catColor, isRef));
+  return row;
+}
+
+function buildGapRow() {
+  const row = document.createElement('div');
+  row.style.cssText = [
+    `height:${ROW_HEIGHT}px`,
+    'display:flex',
+    'align-items:center',
+    'justify-content:center',
+    'font-size:9px',
+    'color:#d1d5db',
+    'font-style:italic',
+    'border-bottom:1px solid rgba(0,0,0,0.03)',
+  ].join(';');
+  row.textContent = '— no ortholog —';
+  return row;
+}
+```
+
+- [ ] **Step 3: Add a stub for toggleExpand (needed so clicks don't error)**
+
+Append to the file:
+
+```js
+// ── Expand / collapse (implemented in Task 8) ────────────────
+function toggleExpand(rowEl, gene, catColor, isRef) {
+  // stub — full implementation in Task 8
+}
+```
+
+- [ ] **Step 4: Verify in browser**
+
+Select two strains. The first 100 reference genes should appear as compact rows in the left column, with matching ortholog rows (or gap rows) in the right column. The SVG center column should show colored bezier paths for connected pairs and red circles for gaps. Functional category colors should be visible as left-border stripes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/js/views/genome-alignment.js
+git commit -m "feat: genome alignment — render gene rows and SVG ribbon"
+```
+
+---
+
+## Task 5: IntersectionObserver pagination
+
+**Files:**
+- Modify: `web/js/views/genome-alignment.js` (append one function)
+
+- [ ] **Step 1: Implement setupObserver()**
+
+Append to the file:
+
+```js
+// ── Pagination ───────────────────────────────────────────────
+function setupObserver() {
+  const sentinel = _container.querySelector('#ga-sentinel');
+  if (!sentinel) return;
+
+  _observer = new IntersectionObserver((entries) => {
+    if (!entries[0].isIntersecting) return;
+    if (_renderedCount >= _refGenes.length) {
+      _observer.disconnect();
+      return;
+    }
+    appendPage();
+  }, {
+    root: _container.querySelector('#ga-list'),
+    rootMargin: '200px',
+  });
+
+  _observer.observe(sentinel);
+}
+```
+
+- [ ] **Step 2: Verify in browser**
+
+Select two strains. Scroll slowly to the bottom of the rendered rows. When the sentinel enters the viewport, the next 100 rows should appear automatically. Repeat until all genes are loaded. The last row should show the highest-numbered locus tag.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/js/views/genome-alignment.js
+git commit -m "feat: genome alignment — IntersectionObserver pagination"
+```
+
+---
+
+## Task 6: Jump chips and search box
+
+**Files:**
+- Modify: `web/js/views/genome-alignment.js` (append functions)
+
+- [ ] **Step 1: Implement buildJumpChips()**
+
+Append to the file:
+
+```js
+// ── Navigation ───────────────────────────────────────────────
+function buildJumpChips() {
+  const chipsEl = _container.querySelector('#ga-jump-chips');
+  const jumpRow = _container.querySelector('#ga-jump-row');
+  chipsEl.innerHTML = '';
+
+  const indices = [];
+  for (let i = 0; i < _refGenes.length; i += 100) indices.push(i);
+  // Always include the last gene
+  if (indices[indices.length - 1] !== _refGenes.length - 1) {
+    indices.push(_refGenes.length - 1);
+  }
+
+  indices.forEach(idx => {
+    const gene  = _refGenes[idx];
+    const label = idx === _refGenes.length - 1
+      ? `${gene.locus_tag} (end)`
+      : gene.locus_tag;
+
+    const btn = document.createElement('button');
+    btn.textContent = label;
+    btn.style.cssText = [
+      'background:#f1f5f9',
+      'border:1px solid #e2e8f0',
+      'border-radius:4px',
+      'padding:2px 7px',
+      'font-size:9px',
+      'color:#475569',
+      'cursor:pointer',
+      'font-family:monospace',
+    ].join(';');
+    btn.addEventListener('click', () => jumpToIndex(idx));
+    chipsEl.appendChild(btn);
+  });
+
+  jumpRow.style.display = 'flex';
+}
+
+function jumpToIndex(targetIdx) {
+  // Render all pages up to and including the target
+  while (_renderedCount <= targetIdx && _renderedCount < _refGenes.length) {
+    appendPage();
+  }
+  // Scroll the target row into view
+  const refCol = _container.querySelector('#ga-ref-col');
+  const rows   = refCol.querySelectorAll('.ga-row');
+  const row    = rows[targetIdx];
+  if (row) {
+    row.scrollIntoView({ block: 'start', behavior: 'smooth' });
+    row.style.outline = '2px solid #3b82f6';
+    setTimeout(() => { row.style.outline = ''; }, 1500);
+  }
+}
+```
+
+- [ ] **Step 2: Implement onSearch()**
+
+Append to the file:
+
+```js
+function onSearch(e) {
+  const query = e.target.value.trim().toLowerCase();
+  if (!query) return;
+
+  const idx = _refGenes.findIndex(g =>
+    g.locus_tag?.toLowerCase().includes(query) ||
+    g.gene_name?.toLowerCase().includes(query) ||
+    g.gene_symbol?.toLowerCase().includes(query)
+  );
+  if (idx === -1) return;
+
+  jumpToIndex(idx);
+}
+```
+
+- [ ] **Step 3: Verify in browser**
+
+After selecting two strains:
+- Jump chips should appear below the pickers, one chip every 100 genes plus an "(end)" chip.
+- Clicking a chip should instantly render all intermediate pages and scroll to that gene.
+- Typing a locus tag (e.g. "CTL0500") in the search box and pressing Enter should scroll to that gene.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/js/views/genome-alignment.js
+git commit -m "feat: genome alignment — jump chips and gene search"
+```
+
+---
+
+## Task 7: Category legend
+
+**Files:**
+- Modify: `web/js/views/genome-alignment.js` (append one function)
+
+- [ ] **Step 1: Implement buildLegend()**
+
+Append to the file:
+
+```js
+// ── Legend ───────────────────────────────────────────────────
+function buildLegend() {
+  const legendRow = _container.querySelector('#ga-legend-row');
+  legendRow.innerHTML = '';
+
+  Object.entries(FUNC_LABELS).forEach(([cat, label]) => {
+    const color = CATEGORY_COLORS[cat] ?? CATEGORY_COLOR_DEFAULT;
+    const item  = document.createElement('span');
+    item.style.cssText = 'display:flex;align-items:center;gap:3px;white-space:nowrap;';
+    item.innerHTML =
+      `<span style="width:8px;height:8px;border-radius:2px;background:${color};flex-shrink:0;display:inline-block;"></span>` +
+      `<span style="color:#6b7280;">${label}</span>`;
+    legendRow.appendChild(item);
+  });
+
+  legendRow.style.display = 'flex';
+}
+```
+
+- [ ] **Step 2: Verify in browser**
+
+After selecting two strains, the legend row should appear below the jump chips showing 17 colored swatches with abbreviated category labels. Colors should match the row borders in the gene list.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/js/views/genome-alignment.js
+git commit -m "feat: genome alignment — functional category legend"
+```
+
+---
+
+## Task 8: Expand-on-click
+
+**Files:**
+- Modify: `web/js/views/genome-alignment.js` (replace toggleExpand stub)
+
+- [ ] **Step 1: Replace the toggleExpand stub with the full implementation**
+
+Find and replace the stub function:
+
+```js
+// ── Expand / collapse (implemented in Task 8) ────────────────
+function toggleExpand(rowEl, gene, catColor, isRef) {
+  // stub — full implementation in Task 8
+}
+```
+
+Replace with:
+
+```js
+// ── Expand / collapse ────────────────────────────────────────
+function toggleExpand(rowEl, gene, catColor, isRef) {
+  const refId = rowEl.dataset.refId;
+
+  // Collapse if clicking the already-expanded row
+  if (_expandedRefId === refId) {
+    collapseExpanded();
+    return;
+  }
+
+  // Collapse previous
+  if (_expandedRefId) collapseExpanded();
+
+  _expandedRefId = refId;
+
+  // Expand the ref row
+  const refCol     = _container.querySelector('#ga-ref-col');
+  const cmpCol     = _container.querySelector('#ga-cmp-col');
+  const refRow     = refCol.querySelector(`.ga-row[data-ref-id="${refId}"]`);
+  const cmpRow     = cmpCol.querySelector(`.ga-row[data-ref-id="${refId}"]`);
+
+  if (refRow) expandRowEl(refRow, gene, catColor, true);
+  if (cmpRow) {
+    // Find comparison gene via the ortholog map
+    const cmpGeneId = _orthologMap.get(refId);
+    const cmpGene   = cmpGeneId ? _cmpGeneMap.get(cmpGeneId) : null;
+    if (cmpGene) expandRowEl(cmpRow, cmpGene, catColor, false);
+  }
+
+  // Highlight ribbon path
+  const svgEl = _container.querySelector('#ga-svg');
+  svgEl.querySelectorAll(`[data-ref-id="${refId}"]`).forEach(el => {
+    el.setAttribute('stroke-width', '14');
+    el.setAttribute('opacity', '0.85');
+  });
+}
+
+function expandRowEl(rowEl, gene, catColor, isRef) {
+  rowEl.style.height   = 'auto';
+  rowEl.style.overflow = 'visible';
+
+  const badge   = CATEGORY_BADGE[gene.functional_category] ?? { bg:'#f9fafb', text:'#6b7280', border:'#e5e7eb' };
+  const catName = FUNC_LABELS[gene.functional_category] ?? gene.functional_category ?? 'Unknown';
+  const product = gene.product ?? '';
+
+  const body = document.createElement('div');
+  body.className = 'ga-expand-body';
+  body.style.cssText = [
+    'position:absolute',
+    `top:${ROW_HEIGHT}px`,
+    'left:-4px',
+    'right:0',
+    'z-index:20',
+    `background:${badge.bg}`,
+    `border:1.5px solid ${badge.border}`,
+    'border-top:none',
+    'padding:6px 8px 8px',
+    'box-shadow:0 4px 12px rgba(0,0,0,0.08)',
+  ].join(';');
+
+  body.innerHTML = [
+    product ? `<div style="font-size:10px;color:#374151;margin-bottom:4px;">${escHtml(product)}</div>` : '',
+    `<span style="display:inline-block;font-size:9px;padding:2px 6px;border-radius:4px;` +
+      `background:${badge.bg};color:${badge.text};border:1px solid ${badge.border};margin-bottom:4px;">` +
+      `${escHtml(catName)}</span>`,
+    isRef
+      ? `<div style="margin-top:4px;"><a href="#" class="ga-detail-link" data-gene-id="${gene.id}" ` +
+        `style="font-size:10px;color:#3b82f6;text-decoration:none;">→ Gene detail</a></div>`
+      : '',
+  ].join('');
+
+  body.querySelector('.ga-detail-link')?.addEventListener('click', (e) => {
+    e.preventDefault();
+    window.__openGeneId = gene.id;
+    window.dispatchEvent(new CustomEvent('chlamatlas:navigate', { detail: { tab: 'genomes' } }));
+  });
+
+  rowEl.style.position = 'relative';
+  rowEl.appendChild(body);
+}
+
+function collapseExpanded() {
+  if (!_expandedRefId) return;
+
+  const refCol = _container.querySelector('#ga-ref-col');
+  const cmpCol = _container.querySelector('#ga-cmp-col');
+
+  [refCol, cmpCol].forEach(col => {
+    const row  = col.querySelector(`.ga-row[data-ref-id="${_expandedRefId}"]`);
+    const body = row?.querySelector('.ga-expand-body');
+    if (body) body.remove();
+    if (row) {
+      row.style.height   = `${ROW_HEIGHT}px`;
+      row.style.overflow = 'hidden';
+    }
+  });
+
+  // Restore ribbon path
+  const svgEl = _container.querySelector('#ga-svg');
+  const refGene = _refGenes.find(g => g.id === _expandedRefId);
+  const strokeW = refGene?.gene_name ? 9 : 7;
+  svgEl.querySelectorAll(`[data-ref-id="${_expandedRefId}"]`).forEach(el => {
+    el.setAttribute('stroke-width', String(strokeW));
+    el.setAttribute('opacity', '0.55');
+  });
+
+  _expandedRefId = null;
+}
+
+function escHtml(str) {
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+```
+
+- [ ] **Step 2: Verify in browser**
+
+Select two strains. Click any gene row. Both the reference and comparison rows should expand to show product + category badge. The ribbon connector for that pair should highlight (thicker, more opaque). The "→ Gene detail" link (ref side only) should navigate to the gene detail page in the Genomes tab. Clicking the same row again should collapse it. Clicking a different row should collapse the previous one first.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/js/views/genome-alignment.js
+git commit -m "feat: genome alignment — expand-on-click with ribbon highlight and gene detail link"
+```
+
+---
+
+## Task 9: Edge case polish
+
+**Files:**
+- Modify: `web/js/views/genome-alignment.js` (small additions)
+- Modify: `web/js/app.js` (one line)
+
+These are all already wired in the HTML scaffold from Task 2. This task verifies each one explicitly.
+
+- [ ] **Step 1: Verify the same-strain warning**
+
+In the browser, select the same strain in both pickers. The yellow warning banner ("Select two different genomes to compare.") should appear and no gene list should load.
+
+If it doesn't show: confirm `showWarning(true)` is called in `onPickerChange()` when `refId === cmpId`.
+
+- [ ] **Step 2: Verify the error banner**
+
+Temporarily break the Supabase URL by editing `loadGenes()` to force an error: change `.from('genes')` to `.from('genes_nonexistent')` for one query, reload, select strains — the red error banner should appear with a "Retry" button. Revert the change.
+
+- [ ] **Step 3: Verify the plasmid footer note**
+
+After selecting two strains and loading genes, scroll to the very bottom of the gene list. The footer "Plasmid genes excluded from this view." should be visible in light gray.
+
+- [ ] **Step 4: Verify the empty state**
+
+Hard-reload the page and navigate to Genome Alignment. Before selecting any strains, the centered text "Select two genomes above to begin." should be visible.
+
+- [ ] **Step 5: Verify the tab active state in the Tools button**
+
+Navigate to Genome Alignment. The "Tools" nav button should be highlighted/active (same behavior as when Sequence Alignment or Structure Alignment is open).
+
+If it doesn't: confirm app.js line 85 now reads:
+```js
+if (toolsBtn) toolsBtn.classList.toggle('active', name === 'alignment' || name === 'structure-alignment' || name === 'genome-alignment');
+```
+
+- [ ] **Step 6: Final end-to-end test**
+
+1. Select CT L2/434 as reference, CM Nigg as comparison
+2. Confirm gene rows load with functional category color stripes
+3. Confirm the category legend and jump chips appear
+4. Click a jump chip — confirm it scrolls to that gene
+5. Type a gene name in search (e.g. "ftsZ") — confirm it jumps and highlights the row
+6. Click a named gene row — confirm expand works on both sides
+7. Click "→ Gene detail" — confirm navigation to Genomes tab
+8. Scroll to the bottom — confirm all ~870 genes load via IntersectionObserver
+9. Select CT L2/434 vs CT D/UW-3 — confirm the tool resets and loads the new pair cleanly
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/js/views/genome-alignment.js
+git commit -m "feat: genome alignment — edge case polish and end-to-end verification"
+```
+
+---
+
+## Done
+
+The Genome Alignment tool is complete. Push to `origin/dev` to trigger a Vercel preview build:
+
+```bash
+git push origin dev
+```
+
+Verify the preview URL shows the tool working correctly before merging to main.

--- a/docs/superpowers/plans/2026-05-29-genome-alignment-redesign.md
+++ b/docs/superpowers/plans/2026-05-29-genome-alignment-redesign.md
@@ -1,0 +1,672 @@
+# Genome Alignment Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign the genome alignment view to use a 3-column layout (jump chips sidebar | constrained gene columns | legend sidebar) with a narrowed connector column, strain icon pickers, and an improved expand card.
+
+**Architecture:** All changes are confined to `web/js/views/genome-alignment.js`. The HTML template is replaced with a flex-row 3-column layout; the SVG ribbon column is narrowed from 24% to 72px with thin lines replacing filled beziers; jump chips and legend move from the topbar into persistent sidebars; the `<select>` pickers gain icon overlays and dynamic strain colors.
+
+**Tech Stack:** Vanilla JS, Supabase JS client (`sb`), SVG
+
+---
+
+## File Map
+
+**Modify only:** `web/js/views/genome-alignment.js`
+
+Functions changing in each task:
+- **Task 1** — `renderGenomeAlignment` (HTML template)
+- **Task 2** — constants block (add `STRAIN_ICONS`), `loadStrains`, new `updatePickerDisplay`
+- **Task 3** — `buildJumpChips`
+- **Task 4** — `buildLegend`
+- **Task 5** — `appendPage`, `collapseExpanded`, `toggleExpand`, `onPickerChange`
+- **Task 6** — `expandRowEl`
+
+---
+
+## Task 1: Replace HTML template with 3-column layout
+
+**Files:**
+- Modify: `web/js/views/genome-alignment.js:97-160`
+
+Replace the `container.innerHTML` string inside `renderGenomeAlignment` with the new 3-column layout. Keep all existing element IDs so downstream functions continue to work. Also add `_closePickersListener` to module state for Task 2.
+
+- [ ] **Step 1: Add `_closePickersListener` to module state block (line ~81)**
+
+```js
+let _observer     = null;      // IntersectionObserver for pagination
+let _container    = null;      // root container div
+let _closePickersListener = null; // document click handler for custom pickers
+```
+
+- [ ] **Step 2: Reset `_closePickersListener` at top of `renderGenomeAlignment`**
+
+In the reset block at the top of `renderGenomeAlignment` (lines 85–95), add:
+
+```js
+if (_closePickersListener) {
+  document.removeEventListener('click', _closePickersListener);
+  _closePickersListener = null;
+}
+```
+
+- [ ] **Step 3: Replace the entire `container.innerHTML = \`...\`` block**
+
+Replace lines 97–160 (the full template string) with:
+
+```js
+  container.innerHTML = `
+    <div id="ga-wrap" style="display:flex;height:calc(100vh - 56px);font-family:system-ui,sans-serif;background:#fff;overflow:hidden;">
+
+      <!-- Left sidebar: Jump chips -->
+      <div id="ga-sidebar-left" style="width:88px;flex-shrink:0;position:sticky;top:0;height:calc(100vh - 56px);display:flex;flex-direction:column;align-items:center;padding:24px 8px 16px;overflow-y:auto;border-right:1px solid #f0f4f8;">
+        <div style="font-size:8px;font-weight:700;letter-spacing:0.1em;color:#94a3b8;text-transform:uppercase;margin-bottom:10px;">Jump to</div>
+        <div id="ga-jump-chips" style="display:flex;flex-direction:column;width:100%;gap:4px;"></div>
+      </div>
+
+      <!-- Center column -->
+      <div style="flex:1;min-width:0;display:flex;flex-direction:column;overflow:hidden;">
+
+        <!-- Sticky picker row -->
+        <div id="ga-picker-row" style="position:sticky;top:0;z-index:10;background:#fff;border-bottom:1px solid #e2e8f0;flex-shrink:0;padding:10px 16px;display:flex;align-items:center;justify-content:center;gap:10px;flex-wrap:wrap;">
+          <div style="position:relative;display:inline-flex;align-items:center;flex-shrink:0;">
+            <img id="ga-ref-icon" style="width:16px;height:16px;object-fit:contain;position:absolute;left:8px;z-index:1;pointer-events:none;display:none;">
+            <select id="ga-ref-picker" style="border:1.5px solid #e2e8f0;border-radius:6px;padding:5px 10px 5px 10px;font-size:12px;font-weight:600;color:#9ca3af;background:#fff;cursor:pointer;">
+              <option value="">Reference genome…</option>
+            </select>
+          </div>
+          <span style="color:#94a3b8;font-size:16px;flex-shrink:0;">⇄</span>
+          <div style="position:relative;display:inline-flex;align-items:center;flex-shrink:0;">
+            <img id="ga-cmp-icon" style="width:16px;height:16px;object-fit:contain;position:absolute;left:8px;z-index:1;pointer-events:none;display:none;">
+            <select id="ga-cmp-picker" style="border:1.5px solid #e2e8f0;border-radius:6px;padding:5px 10px 5px 10px;font-size:12px;font-weight:600;color:#9ca3af;background:#fff;cursor:pointer;">
+              <option value="">Comparison genome…</option>
+            </select>
+          </div>
+          <input id="ga-search" placeholder="🔍 Search gene…" style="border:1px solid #e2e8f0;border-radius:6px;padding:5px 10px;font-size:12px;color:#374151;width:170px;outline:none;background:#f8fafc;">
+        </div>
+
+        <!-- Warning banner (same strain) -->
+        <div id="ga-warning" style="display:none;padding:4px 16px;background:#fef9c3;color:#854d0e;font-size:11px;border-bottom:1px solid #fde68a;">
+          ⚠️ Select two different genomes to compare.
+        </div>
+
+        <!-- Error banner -->
+        <div id="ga-error" style="display:none;padding:6px 16px;background:#fef2f2;color:#991b1b;font-size:11px;border-bottom:1px solid #fecaca;">
+          Failed to load genome data.
+          <button id="ga-retry" style="margin-left:8px;font-size:11px;color:#1d4ed8;background:none;border:none;cursor:pointer;text-decoration:underline;">Retry</button>
+        </div>
+
+        <!-- Empty state -->
+        <div id="ga-empty" style="display:flex;align-items:center;justify-content:center;flex:1;color:#94a3b8;font-size:14px;">
+          Select two genomes above to begin.
+        </div>
+
+        <!-- Gene list -->
+        <div id="ga-list" style="display:none;flex:1;overflow-y:auto;padding:16px 0 24px;">
+          <div style="max-width:680px;margin:0 auto;display:flex;border-radius:6px;overflow:hidden;box-shadow:0 1px 4px rgba(0,0,0,0.07),0 0 0 1px #e2e8f0;">
+            <div id="ga-ref-col" style="flex:1;min-width:0;"></div>
+            <div id="ga-ribbon-col" style="width:72px;flex-shrink:0;position:relative;background:#fafafa;border-left:1px solid #ececec;border-right:1px solid #ececec;">
+              <svg id="ga-svg" width="72" height="0" viewBox="0 0 72 0"
+                style="position:absolute;top:0;left:0;pointer-events:none;"></svg>
+            </div>
+            <div id="ga-cmp-col" style="flex:1;min-width:0;"></div>
+          </div>
+          <div id="ga-sentinel" style="height:1px;"></div>
+          <div id="ga-footer" style="display:none;padding:6px 12px;font-size:10px;color:#9ca3af;text-align:center;">
+            Plasmid genes excluded from this view.
+          </div>
+        </div>
+
+      </div>
+
+      <!-- Right sidebar: Legend -->
+      <div id="ga-sidebar-right" style="width:110px;flex-shrink:0;position:sticky;top:0;height:calc(100vh - 56px);display:flex;flex-direction:column;padding:24px 10px 16px;overflow-y:auto;border-left:1px solid #f0f4f8;">
+        <div style="font-size:8px;font-weight:700;letter-spacing:0.1em;color:#94a3b8;text-transform:uppercase;margin-bottom:10px;text-align:center;">Key</div>
+        <div id="ga-legend-row"></div>
+      </div>
+
+    </div>
+  `;
+```
+
+- [ ] **Step 4: Open the app in the browser and confirm the 3-column skeleton renders**
+
+Navigate to the Tools → Genome Alignment page. You should see: left sidebar (empty, "Jump to" label), center column with picker row, right sidebar ("Key" label). No gene data yet — that's fine.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/js/views/genome-alignment.js
+git commit -m "feat: genome alignment — 3-column layout skeleton"
+```
+
+---
+
+## Task 2: Strain picker icon overlay + dynamic color
+
+**Files:**
+- Modify: `web/js/views/genome-alignment.js` — constants block, `loadStrains`, new `updatePickerDisplay`
+
+Add a `STRAIN_ICONS` constant. When a strain is selected, show its PNG icon overlaid on the left of the `<select>` and update the select's border/text to `strain.color_hex`. Remove `emoji_icon` from option labels.
+
+- [ ] **Step 1: Add `STRAIN_ICONS` constant after the existing constants block (after line ~64)**
+
+```js
+const STRAIN_ICONS = {
+  'CT-L2': '/design/icons_transparent/L2icon_transparent.png',
+  'CT-D':  '/design/icons_transparent/CTDicon_transparent.png',
+  'CM':    '/design/icons_transparent/CMicon_transparent.png',
+};
+```
+
+- [ ] **Step 2: Update option labels in `loadStrains` to use only `common_name` (no emoji)**
+
+In `loadStrains`, replace:
+
+```js
+  data.forEach(s => {
+    const label = `${s.emoji_icon ?? ''} ${s.common_name}`.trim();
+    refPicker.insertAdjacentHTML('beforeend',
+      `<option value="${s.id}">${label}</option>`);
+    cmpPicker.insertAdjacentHTML('beforeend',
+      `<option value="${s.id}">${label}</option>`);
+  });
+```
+
+With:
+
+```js
+  data.forEach(s => {
+    const label = s.common_name;
+    refPicker.insertAdjacentHTML('beforeend',
+      `<option value="${s.id}">${label}</option>`);
+    cmpPicker.insertAdjacentHTML('beforeend',
+      `<option value="${s.id}">${label}</option>`);
+  });
+```
+
+- [ ] **Step 3: Add `updatePickerDisplay` helper function after `loadStrains`**
+
+```js
+function updatePickerDisplay(pickerId, iconElId, strainId) {
+  const strain  = _strains.find(s => s.id === strainId);
+  const picker  = _container.querySelector(`#${pickerId}`);
+  const iconEl  = _container.querySelector(`#${iconElId}`);
+  if (!strain || !picker || !iconEl) return;
+
+  const color   = strain.color_hex ?? '#374151';
+  const iconSrc = STRAIN_ICONS[strain.common_name] ?? '';
+
+  picker.style.borderColor = color;
+  picker.style.color       = color;
+  // Make room for icon when one exists
+  picker.style.paddingLeft = iconSrc ? '30px' : '10px';
+
+  if (iconSrc) {
+    iconEl.src           = iconSrc;
+    iconEl.style.display = '';
+  } else {
+    iconEl.style.display = 'none';
+  }
+}
+```
+
+- [ ] **Step 4: Call `updatePickerDisplay` inside `onPickerChange`**
+
+Add these two calls at the top of `onPickerChange`, after reading `refId` and `cmpId`:
+
+```js
+async function onPickerChange() {
+  const refId = _container.querySelector('#ga-ref-picker').value;
+  const cmpId = _container.querySelector('#ga-cmp-picker').value;
+
+  if (refId) updatePickerDisplay('ga-ref-picker', 'ga-ref-icon', refId);
+  if (cmpId) updatePickerDisplay('ga-cmp-picker', 'ga-cmp-icon', cmpId);
+
+  if (refId === cmpId && refId !== '') {
+    showWarning(true);
+    return;
+  }
+  showWarning(false);
+
+  // (remaining existing body of onPickerChange continues unchanged from here)
+  _loadGen++;
+  _refStrainId  = refId;
+  _cmpStrainId  = cmpId;
+  _renderedCount = 0;
+  _expandedRefId = null;
+  if (_observer) { _observer.disconnect(); _observer = null; }
+
+  _container.querySelector('#ga-ref-col').innerHTML  = '';
+  _container.querySelector('#ga-cmp-col').innerHTML  = '';
+  _container.querySelector('#ga-svg').innerHTML      = '';
+  _container.querySelector('#ga-svg').setAttribute('height', '0');
+  _container.querySelector('#ga-svg').setAttribute('viewBox', '0 0 72 0');
+  _container.querySelector('#ga-list').style.display = 'none';
+  _container.querySelector('#ga-empty').style.display = 'flex';
+  _container.querySelector('#ga-empty').textContent  = 'Loading…';
+  _container.querySelector('#ga-footer').style.display = 'none';
+  showError(false);
+
+  await loadGenes();
+}
+```
+
+- [ ] **Step 5: Select CT-L2 and CT-D in the browser; confirm each picker shows the strain icon with colored border**
+
+The CT-L2 picker should show the L2 icon image with border colored to CT-L2's `color_hex`. CT-D similarly.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/js/views/genome-alignment.js
+git commit -m "feat: genome alignment — strain icon overlay + dynamic picker color"
+```
+
+---
+
+## Task 3: Move jump chips to left sidebar
+
+**Files:**
+- Modify: `web/js/views/genome-alignment.js` — `buildJumpChips`
+
+The left sidebar already has `#ga-jump-chips`. Update `buildJumpChips` to render vertical chips into it and remove references to the now-gone `#ga-jump-row`.
+
+- [ ] **Step 1: Replace `buildJumpChips` entirely**
+
+```js
+function buildJumpChips() {
+  if (!_refGenes.length) return;
+  const chipsEl = _container.querySelector('#ga-jump-chips');
+  if (!chipsEl) return;
+  chipsEl.innerHTML = '';
+
+  const indices = [];
+  for (let i = 0; i < _refGenes.length; i += 100) indices.push(i);
+  if (indices[indices.length - 1] !== _refGenes.length - 1) {
+    indices.push(_refGenes.length - 1);
+  }
+
+  indices.forEach(idx => {
+    const gene  = _refGenes[idx];
+    const label = idx === _refGenes.length - 1
+      ? `${gene.locus_tag} (end)`
+      : gene.locus_tag;
+
+    const btn = document.createElement('button');
+    btn.textContent = label;
+    btn.style.cssText = [
+      'display:block',
+      'width:100%',
+      'background:#f8fafc',
+      'border:1px solid #e2e8f0',
+      'border-radius:5px',
+      'padding:4px 5px',
+      'font-size:8.5px',
+      'color:#475569',
+      'cursor:pointer',
+      'font-family:monospace',
+      'text-align:center',
+      'white-space:nowrap',
+      'overflow:hidden',
+      'text-overflow:ellipsis',
+    ].join(';');
+    btn.addEventListener('mouseenter', () => {
+      btn.style.background = '#eff6ff';
+      btn.style.borderColor = '#93c5fd';
+      btn.style.color = '#1d4ed8';
+    });
+    btn.addEventListener('mouseleave', () => {
+      btn.style.background = '#f8fafc';
+      btn.style.borderColor = '#e2e8f0';
+      btn.style.color = '#475569';
+    });
+    btn.addEventListener('click', () => jumpToIndex(idx));
+    chipsEl.appendChild(btn);
+  });
+}
+```
+
+- [ ] **Step 2: Verify no remaining references to `#ga-jump-row`**
+
+```bash
+grep -n "ga-jump-row" web/js/views/genome-alignment.js
+```
+
+Expected: no output. If any remain, remove them.
+
+- [ ] **Step 3: Load genomes and confirm jump chips appear in left sidebar as a vertical list**
+
+- [ ] **Step 4: Click a chip and confirm it scrolls the gene list to the correct row**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/js/views/genome-alignment.js
+git commit -m "feat: genome alignment — jump chips moved to left sidebar"
+```
+
+---
+
+## Task 4: Move legend to right sidebar
+
+**Files:**
+- Modify: `web/js/views/genome-alignment.js` — `buildLegend`
+
+The right sidebar already has `#ga-legend-row`. Update `buildLegend` to render vertical legend items into it and append the connector legend (line = ortholog, dot = no ortholog).
+
+- [ ] **Step 1: Replace `buildLegend` entirely**
+
+```js
+function buildLegend() {
+  const legendRow = _container.querySelector('#ga-legend-row');
+  if (!legendRow) return;
+  legendRow.innerHTML = '';
+
+  Object.entries(FUNC_LABELS).forEach(([cat, label]) => {
+    const color = CATEGORY_COLORS[cat] ?? CATEGORY_COLOR_DEFAULT;
+    const item  = document.createElement('div');
+    item.style.cssText = 'display:flex;align-items:center;gap:5px;font-size:8.5px;color:#64748b;padding:2.5px 0;';
+    item.innerHTML =
+      `<span style="width:8px;height:8px;border-radius:50%;background:${color};flex-shrink:0;display:inline-block;` +
+      (color === '#FFF100' || color === '#EBEBEB' ? 'border:1px solid #ccc;' : '') +
+      `"></span>` +
+      `<span>${label}</span>`;
+    legendRow.appendChild(item);
+  });
+
+  // Connector legend
+  const connectorLegend = document.createElement('div');
+  connectorLegend.style.cssText = 'margin-top:12px;padding-top:10px;border-top:1px solid #e8edf2;';
+  connectorLegend.innerHTML =
+    `<div style="display:flex;align-items:center;gap:5px;font-size:8.5px;color:#64748b;padding:2.5px 0;">` +
+      `<svg width="20" height="4" style="flex-shrink:0"><line x1="0" y1="2" x2="20" y2="2" stroke="#888" stroke-width="1.5" opacity="0.6"/></svg>` +
+      `Ortholog` +
+    `</div>` +
+    `<div style="display:flex;align-items:center;gap:5px;font-size:8.5px;color:#64748b;padding:2.5px 0;margin-top:2px;">` +
+      `<svg width="20" height="10" style="flex-shrink:0"><circle cx="10" cy="5" r="3.5" fill="#fca5a5" opacity="0.85"/></svg>` +
+      `No ortholog` +
+    `</div>`;
+  legendRow.appendChild(connectorLegend);
+}
+```
+
+- [ ] **Step 2: Verify no remaining references to `#ga-legend-row` using `style.display`**
+
+```bash
+grep -n "ga-legend-row" web/js/views/genome-alignment.js
+```
+
+The only hit should be inside `buildLegend`. Remove any `legendRow.style.display = 'flex'` lines that may remain from the old implementation.
+
+- [ ] **Step 3: Load genomes and confirm the right sidebar populates with all categories plus the ortholog/no-ortholog connector legend at the bottom**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/js/views/genome-alignment.js
+git commit -m "feat: genome alignment — legend moved to right sidebar with connector key"
+```
+
+---
+
+## Task 5: Narrow connector column — thin SVG lines + column subheaders
+
+**Files:**
+- Modify: `web/js/views/genome-alignment.js` — `appendPage`, `collapseExpanded`, `toggleExpand`, `onPickerChange`
+
+Switch SVG from 100-unit viewBox bezier paths to 72px-wide straight lines (1.5px stroke). Add sticky "Reference ↓" / "Comparison ↓" column subheaders on first page render. Fix stroke-width in expand/collapse to match new line weight.
+
+- [ ] **Step 1: Update `appendPage` — add column subheaders on first page**
+
+At the top of the `for` loop inside `appendPage`, add a guard that injects subheaders when `start === 0`:
+
+```js
+function appendPage() {
+  const start = _renderedCount;
+  const end   = Math.min(start + PAGE_SIZE, _refGenes.length);
+  if (start >= _refGenes.length) return;
+
+  const refCol = _container.querySelector('#ga-ref-col');
+  const cmpCol = _container.querySelector('#ga-cmp-col');
+  const svgEl  = _container.querySelector('#ga-svg');
+
+  // Inject sticky column subheaders on first render
+  if (start === 0) {
+    const subheadStyle = 'position:sticky;top:0;z-index:5;padding:5px 9px;font-size:8.5px;font-weight:700;letter-spacing:0.06em;text-transform:uppercase;border-bottom:1px solid;';
+    refCol.insertAdjacentHTML('afterbegin',
+      `<div style="${subheadStyle}background:#eff6ff;color:#3b82f6;border-color:#dbeafe;">Reference ↓</div>`);
+    cmpCol.insertAdjacentHTML('afterbegin',
+      `<div style="${subheadStyle}background:#fffbeb;color:#d97706;border-color:#fde68a;">Comparison ↓</div>`);
+  }
+
+  for (let i = start; i < end; i++) {
+    const refGene   = _refGenes[i];
+    const cmpGeneId = _orthologMap.get(refGene.id) ?? null;
+    const cmpGene   = cmpGeneId ? _cmpGeneMap.get(cmpGeneId) : null;
+    const catColor  = CATEGORY_COLORS[refGene.functional_category] ?? CATEGORY_COLOR_DEFAULT;
+
+    refCol.appendChild(buildRow(refGene, catColor, true));
+    cmpCol.appendChild(cmpGene ? buildRow(cmpGene, catColor, false, refGene.id) : buildGapRow());
+
+    // SVG insertion follows in Step 2 below — replace the existing block:
+```
+
+- [ ] **Step 2: Update SVG element insertion in the `for` loop in `appendPage`**
+
+Replace the existing SVG path/circle insertion block:
+
+```js
+    const y = i * ROW_HEIGHT + ROW_HEIGHT / 2;
+    if (cmpGene) {
+      svgEl.insertAdjacentHTML('beforeend',
+        `<path data-ref-id="${refGene.id}" d="M 0,${y} C 50,${y} 50,${y} 100,${y}"` +
+        ` stroke="${catColor}" stroke-width="${refGene.gene_name ? 9 : 7}"` +
+        ` fill="none" opacity="0.55"/>`);
+    } else {
+      svgEl.insertAdjacentHTML('beforeend',
+        `<circle data-ref-id="${refGene.id}" cx="50" cy="${y}" r="4"` +
+        ` fill="#fca5a5" opacity="0.8"/>`);
+    }
+```
+
+With:
+
+```js
+    const y = i * ROW_HEIGHT + ROW_HEIGHT / 2;
+    if (cmpGene) {
+      svgEl.insertAdjacentHTML('beforeend',
+        `<line data-ref-id="${refGene.id}" x1="0" y1="${y}" x2="72" y2="${y}"` +
+        ` stroke="${catColor}" stroke-width="1.5" opacity="0.65"/>`);
+    } else {
+      svgEl.insertAdjacentHTML('beforeend',
+        `<circle data-ref-id="${refGene.id}" cx="36" cy="${y}" r="4"` +
+        ` fill="#fca5a5" opacity="0.8"/>`);
+    }
+```
+
+- [ ] **Step 3: Update SVG viewBox in `appendPage`**
+
+Replace:
+
+```js
+  svgEl.setAttribute('viewBox', `0 0 100 ${totalH}`);
+```
+
+With:
+
+```js
+  svgEl.setAttribute('viewBox', `0 0 72 ${totalH}`);
+```
+
+- [ ] **Step 4: Update SVG viewBox reset in `onPickerChange`**
+
+Find and replace:
+
+```js
+  _container.querySelector('#ga-svg').setAttribute('viewBox', '0 0 100 0');
+```
+
+With:
+
+```js
+  _container.querySelector('#ga-svg').setAttribute('viewBox', '0 0 72 0');
+```
+
+- [ ] **Step 5: Update expand highlight in `toggleExpand`**
+
+Replace:
+
+```js
+  svgEl.querySelectorAll(`[data-ref-id="${refId}"]`).forEach(el => {
+    el.setAttribute('stroke-width', '14');
+    el.setAttribute('opacity', '0.85');
+  });
+```
+
+With:
+
+```js
+  svgEl.querySelectorAll(`[data-ref-id="${refId}"]`).forEach(el => {
+    el.setAttribute('stroke-width', '3');
+    el.setAttribute('opacity', '0.9');
+  });
+```
+
+- [ ] **Step 6: Update collapse restore in `collapseExpanded`**
+
+Replace:
+
+```js
+  const refGene = _refGenes.find(g => g.id === _expandedRefId);
+  const strokeW = refGene?.gene_name ? 9 : 7;
+  svgEl.querySelectorAll(`[data-ref-id="${_expandedRefId}"]`).forEach(el => {
+    el.setAttribute('stroke-width', String(strokeW));
+    el.setAttribute('opacity', '0.55');
+  });
+```
+
+With:
+
+```js
+  svgEl.querySelectorAll(`[data-ref-id="${_expandedRefId}"]`).forEach(el => {
+    el.setAttribute('stroke-width', '1.5');
+    el.setAttribute('opacity', '0.65');
+  });
+```
+
+- [ ] **Step 7: Load genomes in browser and verify**
+  - Connector column is ~72px wide
+  - Lines are thin colored horizontals (not thick ribbons)
+  - "— no ortholog —" rows show a small pink dot in the connector
+  - "Reference ↓" and "Comparison ↓" sticky subheaders appear at top of columns
+  - Clicking a row highlights its connector line, clicking again restores it
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/js/views/genome-alignment.js
+git commit -m "feat: genome alignment — narrow connector column with thin SVG lines"
+```
+
+---
+
+## Task 6: Expand card — gene detail on both columns + protein data
+
+**Files:**
+- Modify: `web/js/views/genome-alignment.js` — `expandRowEl`
+
+Add → Gene detail link to the comparison column (currently only reference has it). Fetch protein mass and length lazily and inject into the card when available.
+
+- [ ] **Step 1: Replace `expandRowEl` entirely**
+
+```js
+function expandRowEl(rowEl, gene, catColor, isRef) {
+  rowEl.style.height   = 'auto';
+  rowEl.style.overflow = 'visible';
+
+  const badge   = CATEGORY_BADGE[gene.functional_category] ?? { bg:'#f9fafb', text:'#6b7280', border:'#e5e7eb' };
+  const catName = FUNC_LABELS[gene.functional_category] ?? gene.functional_category ?? 'Unknown';
+  const product = gene.product ?? '';
+
+  const body = document.createElement('div');
+  body.className = 'ga-expand-body';
+  body.style.cssText = [
+    'position:absolute',
+    `top:${ROW_HEIGHT}px`,
+    'left:-4px',
+    'right:0',
+    'z-index:20',
+    `background:${badge.bg}`,
+    `border:1.5px solid ${badge.border}`,
+    'border-top:none',
+    'padding:6px 8px 8px',
+    'box-shadow:0 4px 12px rgba(0,0,0,0.08)',
+  ].join(';');
+
+  const protId = `ga-prot-${gene.id}`;
+  body.innerHTML = [
+    product ? `<div style="font-size:10px;color:#374151;margin-bottom:4px;">${escHtml(product)}</div>` : '',
+    `<span style="display:inline-block;font-size:9px;padding:2px 6px;border-radius:4px;` +
+      `background:${badge.bg};color:${badge.text};border:1px solid ${badge.border};margin-bottom:4px;">` +
+      `${escHtml(catName)}</span>`,
+    `<div id="${protId}" style="font-size:9px;color:#9ca3af;margin-top:2px;"></div>`,
+    `<div style="margin-top:4px;"><a href="#" class="ga-detail-link" data-gene-id="${gene.id}" ` +
+      `style="font-size:10px;color:#3b82f6;text-decoration:none;">→ Gene detail</a></div>`,
+  ].join('');
+
+  body.querySelector('.ga-detail-link')?.addEventListener('click', (e) => {
+    e.preventDefault();
+    window.__openGeneId = gene.id;
+    window.dispatchEvent(new CustomEvent('chlamatlas:navigate', { detail: { tab: 'genomes' } }));
+  });
+
+  rowEl.style.position = 'relative';
+  rowEl.appendChild(body);
+
+  // Lazy-load protein size data
+  sb.from('proteins')
+    .select('mass_kd,length_aa')
+    .eq('gene_id', gene.id)
+    .maybeSingle()
+    .then(({ data }) => {
+      const el = body.querySelector(`#${protId}`);
+      if (!el || !data) return;
+      const parts = [];
+      if (data.length_aa) parts.push(`${data.length_aa} aa`);
+      if (data.mass_kd)   parts.push(`${data.mass_kd} kDa`);
+      if (parts.length) el.textContent = parts.join(' · ');
+    });
+}
+```
+
+- [ ] **Step 2: Verify `isRef` is no longer referenced in `expandRowEl`**
+
+```bash
+grep -n "isRef" web/js/views/genome-alignment.js
+```
+
+`isRef` is still a parameter in `toggleExpand` → `expandRowEl` call sites. The parameter can remain in the function signature for now (it's passed but unused). Confirm the function signature still matches its two call sites in `toggleExpand`:
+
+```js
+if (refRow) expandRowEl(refRow, refGene, catColor, true);
+if (cmpGene) expandRowEl(cmpRow, cmpGene, catColor, false);
+```
+
+Both are unchanged — no edits needed to `toggleExpand`.
+
+- [ ] **Step 3: Expand a gene row and verify**
+  - Product description shows
+  - Category badge shows
+  - Protein aa/kDa appears within a moment (async)
+  - "→ Gene detail" link appears in **both** reference and comparison columns
+  - Clicking "→ Gene detail" navigates to the gene detail page
+
+- [ ] **Step 4: Expand a gene with no ortholog (comparison side shows "— no ortholog —") and verify only the reference side expands with no JS errors**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/js/views/genome-alignment.js
+git commit -m "feat: genome alignment — expand card shows gene detail on both sides + protein size"
+```

--- a/docs/superpowers/specs/2026-05-29-genome-alignment-redesign.md
+++ b/docs/superpowers/specs/2026-05-29-genome-alignment-redesign.md
@@ -1,0 +1,115 @@
+# Genome Alignment Redesign — Design Spec
+**Date:** 2026-05-29  
+**Status:** Approved
+
+---
+
+## Problem
+
+The current genome alignment view uses full browser width for two gene columns with a 24%-wide SVG ribbon area. This creates too much horizontal dead space, the ribbon connectors (filled bezier curves) read as mysterious rather than conveying synteny, and the jump chips + legend consume vertical real estate in the topbar. The tool doesn't immediately read as a side-by-side comparison.
+
+---
+
+## Design Decisions
+
+### 1. Overall Layout
+
+Three-column page layout replacing the current single scrollable area:
+
+```
+[ Left sidebar ] [ Center: pickers + gene columns ] [ Right sidebar ]
+```
+
+- **Left sidebar** (`88px` fixed): Jump-to chips, sticky alongside scroll
+- **Center** (flex:1): Genome pickers row + scrollable gene comparison
+- **Right sidebar** (`110px` fixed): Category key + connector legend, sticky alongside scroll
+- All white background — no gray page tint
+- Subtle `border-right` on left sidebar, `border-left` on right sidebar
+
+### 2. Center — Genome Pickers
+
+- Single sticky row below the navbar, centered over the gene columns
+- Contains: ref picker `⇄` cmp picker + search box (right-aligned in the same row)
+- Picker styling is **dynamic**: border and text color set to `strain.color_hex` after selection
+- Picker displays a **strain icon** (16×16 `<img>`) next to the strain name
+  - Since `<select>` cannot render images, implement as a **custom dropdown** (button + popover list)
+  - Icon paths from existing mapping:
+    - CT-L2 → `/design/icons_transparent/L2icon_transparent.png`
+    - CT-D → `/design/icons_transparent/CTDicon_transparent.png`
+    - CM → `/design/icons_transparent/CMicon_transparent.png`
+  - Before selection: neutral styling (gray border, placeholder text)
+  - After selection: border + label color = `strain.color_hex`
+
+### 3. Center — Gene Columns
+
+- **Max-width: 680px**, `margin: 0 auto` — centered in the available space between sidebars
+- Wrapped in a white rounded card with a subtle box-shadow and border
+- Three sub-columns:
+  - **Reference column** (`flex: 1`): sticky "Reference ↓" subheader in blue tint
+  - **Connector column** (`72px` fixed): SVG with thin `1.5px` category-colored horizontal lines for orthologs; `r=4` red dot for no-ortholog
+  - **Comparison column** (`flex: 1`): sticky "Comparison ↓" subheader in amber tint
+- Column subheaders are sticky within the scroll container (not viewport-sticky)
+- Gene rows: `22px` height, `border-left: 4px solid {catColor}`, faint category bg tint, monospace locus tag + colored gene name
+
+### 4. Connector Column
+
+- **Width: 72px** (up from current ~24% which was visually dominant)
+- Background: `#fafafa`, bordered with `#ececec` on both sides
+- SVG lines: `stroke-width: 1.5`, category color, `opacity: 0.65`
+- No-ortholog indicator: filled circle `r=4`, `fill: #fca5a5`, `opacity: 0.8`
+- On row expand: highlight matching path/circle to `stroke-width: 3`, `opacity: 0.9`
+- Replaces the current filled bezier ribbon approach entirely
+
+### 5. Left Sidebar — Jump Chips
+
+- Label: "JUMP TO" in small caps (`8px`, `#94a3b8`)
+- `24px` top padding from navbar (visual breathing room)
+- Each chip: monospace, `8.5px`, white bg, `#e2e8f0` border, rounded — hover state goes blue
+- Chips are generated from reference genome after load (every 100 genes + end)
+- Chips remain visible and functional as user scrolls the gene list
+
+### 6. Right Sidebar — Key
+
+- Label: "KEY" in small caps
+- `24px` top padding from navbar
+- One row per functional category: 8px colored dot + label (`8.5px`, `#64748b`)
+- Below a divider: two rows showing connector legend:
+  - `————` line + "Ortholog"
+  - `●` dot + "No ortholog"
+
+### 7. Expand on Click
+
+Keep existing expand behavior. Add to expanded card:
+- **→ Gene detail** link on **both** reference and comparison columns (currently only reference has it)
+- Gene length (aa) and protein mass (kDa) if available from proteins table join
+
+### 8. Removed from Topbar
+
+- Jump chip row (moved to left sidebar)
+- Category legend row (moved to right sidebar)
+- Topbar now has one row only: pickers + search
+
+### 9. Spacing / Visual Hierarchy
+
+From top to bottom:
+1. Global nav (dark green, 46px)
+2. Picker row (white, 1px bottom border) — pickers centered
+3. `16px` padding before gene card
+4. Column subheaders (sticky within scroll, blue/amber tint)
+5. Gene rows
+
+---
+
+## Files Affected
+
+- `web/js/views/genome-alignment.js` — primary change (full layout rewrite)
+
+## What Stays the Same
+
+- Jump chip scroll-to logic
+- Gene search logic
+- IntersectionObserver pagination
+- Expand/collapse row behavior
+- Category color constants
+- Ortholog data fetching
+- Stale-fetch guard (`_loadGen`)

--- a/web/index.html
+++ b/web/index.html
@@ -137,6 +137,11 @@
       <div id="structure-alignment-content"></div>
     </section>
 
+    <!-- GENOME ALIGNMENT TAB -->
+    <section id="tab-genome-alignment" class="tab-panel hidden">
+      <div id="genome-alignment-content"></div>
+    </section>
+
   </main>
 
   <!-- ─── MOBILE BOTTOM NAV ─────────────────────────────────── -->

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -7,6 +7,7 @@ import { renderPipeline } from './views/pipeline.js?v=65';
 import { renderRoadmap }  from './views/roadmap.js?v=90';
 import { renderAlignment } from './views/alignment.js?v=96';
 import { renderStructureAlignment } from './views/structure-alignment.js?v=6';
+import { renderGenomeAlignment } from './views/genome-alignment.js?v=1';
 
 export { sb, state };
 
@@ -27,6 +28,7 @@ function wireNavStubs() {
 function showToolsPopover(anchor) {
   const seqIcon = `<svg width="15" height="15" viewBox="0 0 15 15" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" style="display:block;flex-shrink:0;opacity:0.7"><line x1="1" y1="4" x2="11" y2="4"/><line x1="4" y1="7.5" x2="14" y2="7.5"/><line x1="2" y1="11" x2="12" y2="11"/></svg>`;
   const structIcon = `<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="display:block;flex-shrink:0;opacity:0.7"><path d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9"/></svg>`;
+  const genomeIcon = `<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="display:block;flex-shrink:0;opacity:0.7"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>`;
   const pop = openNavPopover(anchor, `
     <div class="nav-popover-label">Tools</div>
     <button class="nav-popover-row" id="tools-pop-seq">
@@ -37,6 +39,10 @@ function showToolsPopover(anchor) {
       <span class="nav-popover-row-icon">${structIcon}</span>
       <span class="nav-popover-row-name">Structure Alignment</span>
     </button>
+    <button class="nav-popover-row" id="tools-pop-genome">
+      <span class="nav-popover-row-icon">${genomeIcon}</span>
+      <span class="nav-popover-row-name">Genome Alignment</span>
+    </button>
   `, 'tools-nav-popover');
   pop?.querySelector('#tools-pop-seq')?.addEventListener('click', () => {
     pop.remove();
@@ -46,10 +52,14 @@ function showToolsPopover(anchor) {
     pop.remove();
     activateTab('structure-alignment');
   });
+  pop?.querySelector('#tools-pop-genome')?.addEventListener('click', () => {
+    pop.remove();
+    activateTab('genome-alignment');
+  });
 }
 
 // ─── Tab routing ──────────────────────────────────────────
-const TABS = ['home', 'genomes', 'mutants', 'pipeline', 'roadmap', 'alignment', 'structure-alignment'];
+const TABS = ['home', 'genomes', 'mutants', 'pipeline', 'roadmap', 'alignment', 'structure-alignment', 'genome-alignment'];
 const RENDERERS = {
   home:      renderHome,
   genomes:   renderGenomes,
@@ -58,6 +68,7 @@ const RENDERERS = {
   roadmap:   renderRoadmap,
   alignment: renderAlignment,
   'structure-alignment': renderStructureAlignment,
+  'genome-alignment':    renderGenomeAlignment,
 };
 
 function activateTab(name) {
@@ -82,7 +93,7 @@ function activateTab(name) {
   });
   // Tools button has no data-tab (it's a dropdown trigger); mark it active when on alignment
   const toolsBtn = document.getElementById('nav-tools-btn');
-  if (toolsBtn) toolsBtn.classList.toggle('active', name === 'alignment' || name === 'structure-alignment');
+  if (toolsBtn) toolsBtn.classList.toggle('active', name === 'alignment' || name === 'structure-alignment' || name === 'genome-alignment');
   document.querySelectorAll('.mobile-tab').forEach(btn => {
     btn.classList.toggle('active', btn.dataset.tab === name);
   });

--- a/web/js/views/genome-alignment.js
+++ b/web/js/views/genome-alignment.js
@@ -117,22 +117,32 @@ export async function renderGenomeAlignment(container) {
       <!-- Center column -->
       <div style="flex:1;min-width:0;display:flex;flex-direction:column;overflow:hidden;">
 
-        <!-- Sticky picker row -->
-        <div id="ga-picker-row" style="position:sticky;top:0;z-index:10;background:#fff;border-bottom:1px solid #e2e8f0;flex-shrink:0;padding:10px 16px;display:flex;align-items:center;justify-content:center;gap:10px;flex-wrap:wrap;">
-          <div style="position:relative;display:inline-flex;align-items:center;flex-shrink:0;">
-            <img id="ga-ref-icon" style="width:16px;height:16px;object-fit:contain;position:absolute;left:8px;z-index:1;pointer-events:none;display:none;">
-            <select id="ga-ref-picker" style="border:1.5px solid #e2e8f0;border-radius:6px;padding:5px 10px 5px 10px;font-size:12px;font-weight:600;color:#9ca3af;background:#fff;cursor:pointer;">
-              <option value="">Reference genome…</option>
-            </select>
+        <!-- Sticky picker + col-headers area -->
+        <div style="position:sticky;top:0;z-index:10;background:#fff;border-bottom:1px solid #e2e8f0;flex-shrink:0;">
+          <div id="ga-picker-row" style="padding:10px 16px;display:flex;align-items:center;justify-content:center;gap:10px;flex-wrap:wrap;">
+            <div style="position:relative;display:inline-flex;align-items:center;flex-shrink:0;">
+              <img id="ga-ref-icon" style="width:16px;height:16px;object-fit:contain;position:absolute;left:9px;z-index:1;pointer-events:none;display:none;">
+              <select id="ga-ref-picker" style="border:1.5px solid #e2e8f0;border-radius:6px;padding:5px 10px 5px 10px;font-size:12px;font-weight:600;color:#9ca3af;background:#fff;cursor:pointer;">
+                <option value="">Reference genome…</option>
+              </select>
+            </div>
+            <span style="color:#94a3b8;font-size:16px;flex-shrink:0;">⇄</span>
+            <div style="position:relative;display:inline-flex;align-items:center;flex-shrink:0;">
+              <img id="ga-cmp-icon" style="width:16px;height:16px;object-fit:contain;position:absolute;left:9px;z-index:1;pointer-events:none;display:none;">
+              <select id="ga-cmp-picker" style="border:1.5px solid #e2e8f0;border-radius:6px;padding:5px 10px 5px 10px;font-size:12px;font-weight:600;color:#9ca3af;background:#fff;cursor:pointer;">
+                <option value="">Comparison genome…</option>
+              </select>
+            </div>
+            <input id="ga-search" placeholder="🔍 Search gene…" style="border:1px solid #e2e8f0;border-radius:6px;padding:5px 10px;font-size:12px;color:#374151;width:170px;outline:none;background:#f8fafc;">
           </div>
-          <span style="color:#94a3b8;font-size:16px;flex-shrink:0;">⇄</span>
-          <div style="position:relative;display:inline-flex;align-items:center;flex-shrink:0;">
-            <img id="ga-cmp-icon" style="width:16px;height:16px;object-fit:contain;position:absolute;left:8px;z-index:1;pointer-events:none;display:none;">
-            <select id="ga-cmp-picker" style="border:1.5px solid #e2e8f0;border-radius:6px;padding:5px 10px 5px 10px;font-size:12px;font-weight:600;color:#9ca3af;background:#fff;cursor:pointer;">
-              <option value="">Comparison genome…</option>
-            </select>
+          <!-- Column labels — shown after genes load, always above scroll content -->
+          <div id="ga-col-headers" style="display:none;max-width:680px;margin:0 auto;width:100%;border-top:1px solid #f0f4f8;">
+            <div style="display:flex;">
+              <div style="flex:1;padding:3px 9px 4px;font-size:8px;font-weight:700;letter-spacing:0.07em;text-transform:uppercase;color:#94a3b8;">Reference</div>
+              <div style="width:72px;flex-shrink:0;"></div>
+              <div style="flex:1;padding:3px 9px 4px;font-size:8px;font-weight:700;letter-spacing:0.07em;text-transform:uppercase;color:#94a3b8;">Comparison</div>
+            </div>
           </div>
-          <input id="ga-search" placeholder="🔍 Search gene…" style="border:1px solid #e2e8f0;border-radius:6px;padding:5px 10px;font-size:12px;color:#374151;width:170px;outline:none;background:#f8fafc;">
         </div>
 
         <!-- Warning banner (same strain) -->
@@ -232,7 +242,7 @@ function updatePickerDisplay(pickerId, iconElId, strainId) {
   picker.style.borderColor = color;
   picker.style.color       = color;
   // Make room for icon when one exists
-  picker.style.paddingLeft = iconSrc ? '30px' : '10px';
+  picker.style.paddingLeft = iconSrc ? '34px' : '10px';
 
   if (iconSrc) {
     iconEl.src           = iconSrc;
@@ -279,8 +289,9 @@ async function onPickerChange() {
   _container.querySelector('#ga-svg').innerHTML      = '';
   _container.querySelector('#ga-svg').setAttribute('height', '0');
   _container.querySelector('#ga-svg').setAttribute('viewBox', '0 0 72 0');
-  _container.querySelector('#ga-list').style.display = 'none';
-  _container.querySelector('#ga-empty').style.display = 'flex';
+  _container.querySelector('#ga-list').style.display        = 'none';
+  _container.querySelector('#ga-col-headers').style.display = 'none';
+  _container.querySelector('#ga-empty').style.display       = 'flex';
   _container.querySelector('#ga-empty').textContent  = 'Loading…';
   _container.querySelector('#ga-legend-row').innerHTML = '';
   _container.querySelector('#ga-footer').style.display     = 'none';
@@ -358,9 +369,10 @@ async function loadGenes() {
   // Ready to render
   buildJumpChips();
   buildLegend();
-  _container.querySelector('#ga-empty').style.display = 'none';
-  _container.querySelector('#ga-list').style.display  = 'block';
-  _container.querySelector('#ga-footer').style.display = 'block';
+  _container.querySelector('#ga-empty').style.display      = 'none';
+  _container.querySelector('#ga-list').style.display       = 'block';
+  _container.querySelector('#ga-col-headers').style.display = 'block';
+  _container.querySelector('#ga-footer').style.display     = 'block';
   appendPage();
   setupObserver();
 }
@@ -457,15 +469,6 @@ function appendPage() {
   const cmpCol = _container.querySelector('#ga-cmp-col');
   const svgEl  = _container.querySelector('#ga-svg');
 
-  // Inject sticky column subheaders on first render
-  if (start === 0) {
-    const subheadStyle = 'position:sticky;top:0;z-index:5;padding:5px 9px;font-size:8.5px;font-weight:700;letter-spacing:0.06em;text-transform:uppercase;border-bottom:1px solid;';
-    refCol.insertAdjacentHTML('afterbegin',
-      `<div style="${subheadStyle}background:#eff6ff;color:#3b82f6;border-color:#dbeafe;">Reference ↓</div>`);
-    cmpCol.insertAdjacentHTML('afterbegin',
-      `<div style="${subheadStyle}background:#fffbeb;color:#d97706;border-color:#fde68a;">Comparison ↓</div>`);
-  }
-
   for (let i = start; i < end; i++) {
     const refGene   = _refGenes[i];
     const cmpGeneId = _orthologMap.get(refGene.id) ?? null;
@@ -479,7 +482,7 @@ function appendPage() {
     if (cmpGene) {
       svgEl.insertAdjacentHTML('beforeend',
         `<line data-ref-id="${refGene.id}" x1="0" y1="${y}" x2="72" y2="${y}"` +
-        ` stroke="${catColor}" stroke-width="1.5" opacity="0.65"/>`);
+        ` stroke="${catColor}" stroke-width="1.5" opacity="0.2"/>`);
     } else {
       svgEl.insertAdjacentHTML('beforeend',
         `<circle data-ref-id="${refGene.id}" cx="36" cy="${y}" r="4"` +
@@ -669,7 +672,7 @@ function collapseExpanded() {
   const svgEl = _container.querySelector('#ga-svg');
   svgEl.querySelectorAll(`[data-ref-id="${_expandedRefId}"]`).forEach(el => {
     el.setAttribute('stroke-width', '1.5');
-    el.setAttribute('opacity', '0.65');
+    el.setAttribute('opacity', '0.2');
   });
 
   _expandedRefId = null;
@@ -712,7 +715,7 @@ function buildLegend() {
   Object.entries(FUNC_LABELS).forEach(([cat, label]) => {
     const color = CATEGORY_COLORS[cat] ?? CATEGORY_COLOR_DEFAULT;
     const item  = document.createElement('div');
-    item.style.cssText = 'display:flex;align-items:center;gap:5px;font-size:8.5px;color:#64748b;padding:2.5px 0;';
+    item.style.cssText = 'display:flex;align-items:center;gap:5px;font-size:10px;color:#64748b;padding:2.5px 0;';
     item.innerHTML =
       `<span style="width:8px;height:8px;border-radius:50%;background:${color};flex-shrink:0;display:inline-block;` +
       (color === '#FFF100' || color === '#EBEBEB' ? 'border:1px solid #ccc;' : '') +
@@ -725,7 +728,7 @@ function buildLegend() {
   const connectorLegend = document.createElement('div');
   connectorLegend.style.cssText = 'margin-top:12px;padding-top:10px;border-top:1px solid #e8edf2;';
   connectorLegend.innerHTML =
-    `<div style="display:flex;align-items:center;gap:5px;font-size:8.5px;color:#64748b;padding:2.5px 0;">` +
+    `<div style="display:flex;align-items:center;gap:5px;font-size:10px;color:#64748b;padding:2.5px 0;">` +
       `<svg width="20" height="4" style="flex-shrink:0"><line x1="0" y1="2" x2="20" y2="2" stroke="#888" stroke-width="1.5" opacity="0.6"/></svg>` +
       `Ortholog` +
     `</div>` +

--- a/web/js/views/genome-alignment.js
+++ b/web/js/views/genome-alignment.js
@@ -120,16 +120,16 @@ export async function renderGenomeAlignment(container) {
         <!-- Sticky picker + col-headers area -->
         <div style="position:sticky;top:0;z-index:10;background:#fff;border-bottom:1px solid #e2e8f0;flex-shrink:0;">
           <div id="ga-picker-row" style="padding:10px 16px;display:flex;align-items:center;justify-content:center;gap:10px;flex-wrap:wrap;">
-            <div style="position:relative;display:inline-flex;align-items:center;flex-shrink:0;">
-              <img id="ga-ref-icon" style="width:16px;height:16px;object-fit:contain;position:absolute;left:9px;z-index:1;pointer-events:none;display:none;">
-              <select id="ga-ref-picker" style="border:1.5px solid #e2e8f0;border-radius:6px;padding:5px 10px 5px 10px;font-size:12px;font-weight:600;color:#9ca3af;background:#fff;cursor:pointer;">
+            <div id="ga-ref-picker-wrap" style="display:inline-flex;align-items:center;gap:5px;border:1.5px solid #e2e8f0;border-radius:6px;padding:4px 8px;background:#fff;flex-shrink:0;">
+              <img id="ga-ref-icon" style="width:16px;height:16px;object-fit:contain;display:none;flex-shrink:0;">
+              <select id="ga-ref-picker" style="border:none;outline:none;font-size:12px;font-weight:600;color:#9ca3af;background:transparent;cursor:pointer;padding:0;">
                 <option value="">Reference genome…</option>
               </select>
             </div>
             <span style="color:#94a3b8;font-size:16px;flex-shrink:0;">⇄</span>
-            <div style="position:relative;display:inline-flex;align-items:center;flex-shrink:0;">
-              <img id="ga-cmp-icon" style="width:16px;height:16px;object-fit:contain;position:absolute;left:9px;z-index:1;pointer-events:none;display:none;">
-              <select id="ga-cmp-picker" style="border:1.5px solid #e2e8f0;border-radius:6px;padding:5px 10px 5px 10px;font-size:12px;font-weight:600;color:#9ca3af;background:#fff;cursor:pointer;">
+            <div id="ga-cmp-picker-wrap" style="display:inline-flex;align-items:center;gap:5px;border:1.5px solid #e2e8f0;border-radius:6px;padding:4px 8px;background:#fff;flex-shrink:0;">
+              <img id="ga-cmp-icon" style="width:16px;height:16px;object-fit:contain;display:none;flex-shrink:0;">
+              <select id="ga-cmp-picker" style="border:none;outline:none;font-size:12px;font-weight:600;color:#9ca3af;background:transparent;cursor:pointer;padding:0;">
                 <option value="">Comparison genome…</option>
               </select>
             </div>
@@ -233,16 +233,16 @@ async function loadStrains() {
 function updatePickerDisplay(pickerId, iconElId, strainId) {
   const strain  = _strains.find(s => s.id === strainId);
   const picker  = _container.querySelector(`#${pickerId}`);
+  const wrap    = _container.querySelector(`#${pickerId}-wrap`);
   const iconEl  = _container.querySelector(`#${iconElId}`);
   if (!strain || !picker || !iconEl) return;
 
   const color   = strain.color_hex ?? '#374151';
   const iconSrc = STRAIN_ICONS[strain.common_name] ?? '';
 
-  picker.style.borderColor = color;
-  picker.style.color       = color;
-  // Make room for icon when one exists
-  picker.style.paddingLeft = iconSrc ? '34px' : '10px';
+  // Border lives on the wrapper, text color on the select
+  if (wrap) wrap.style.borderColor = color;
+  picker.style.color = color;
 
   if (iconSrc) {
     iconEl.src           = iconSrc;

--- a/web/js/views/genome-alignment.js
+++ b/web/js/views/genome-alignment.js
@@ -369,11 +369,11 @@ async function loadGenes() {
 function buildJumpChips() {
   if (!_refGenes.length) return;
   const chipsEl = _container.querySelector('#ga-jump-chips');
+  if (!chipsEl) return;
   chipsEl.innerHTML = '';
 
   const indices = [];
   for (let i = 0; i < _refGenes.length; i += 100) indices.push(i);
-  // Always include the last gene
   if (indices[indices.length - 1] !== _refGenes.length - 1) {
     indices.push(_refGenes.length - 1);
   }
@@ -387,20 +387,34 @@ function buildJumpChips() {
     const btn = document.createElement('button');
     btn.textContent = label;
     btn.style.cssText = [
-      'background:#f1f5f9',
+      'display:block',
+      'width:100%',
+      'background:#f8fafc',
       'border:1px solid #e2e8f0',
-      'border-radius:4px',
-      'padding:2px 7px',
-      'font-size:9px',
+      'border-radius:5px',
+      'padding:4px 5px',
+      'font-size:8.5px',
       'color:#475569',
       'cursor:pointer',
       'font-family:monospace',
+      'text-align:center',
+      'white-space:nowrap',
+      'overflow:hidden',
+      'text-overflow:ellipsis',
     ].join(';');
+    btn.addEventListener('mouseenter', () => {
+      btn.style.background = '#eff6ff';
+      btn.style.borderColor = '#93c5fd';
+      btn.style.color = '#1d4ed8';
+    });
+    btn.addEventListener('mouseleave', () => {
+      btn.style.background = '#f8fafc';
+      btn.style.borderColor = '#e2e8f0';
+      btn.style.color = '#475569';
+    });
     btn.addEventListener('click', () => jumpToIndex(idx));
     chipsEl.appendChild(btn);
   });
-
-  // chips are always visible in the left sidebar — no show/hide needed
 }
 
 function jumpToIndex(targetIdx) {

--- a/web/js/views/genome-alignment.js
+++ b/web/js/views/genome-alignment.js
@@ -204,6 +204,106 @@ function showWarning(visible) {
   _container.querySelector('#ga-warning').style.display = visible ? 'block' : 'none';
 }
 
-// stubs — replaced in Task 3 and Task 6
-function onPickerChange() {}
+// ── Strain selection handler ──────────────────────────────────
+async function onPickerChange() {
+  const refId = _container.querySelector('#ga-ref-picker').value;
+  const cmpId = _container.querySelector('#ga-cmp-picker').value;
+
+  if (!refId || !cmpId) return;
+
+  if (refId === cmpId) {
+    showWarning(true);
+    return;
+  }
+  showWarning(false);
+
+  _refStrainId  = refId;
+  _cmpStrainId  = cmpId;
+  _renderedCount = 0;
+  _expandedRefId = null;
+  if (_observer) { _observer.disconnect(); _observer = null; }
+
+  // Reset list
+  _container.querySelector('#ga-ref-col').innerHTML  = '';
+  _container.querySelector('#ga-cmp-col').innerHTML  = '';
+  _container.querySelector('#ga-svg').innerHTML      = '';
+  _container.querySelector('#ga-svg').setAttribute('height', '0');
+  _container.querySelector('#ga-svg').setAttribute('viewBox', '0 0 100 0');
+  _container.querySelector('#ga-list').style.display = 'none';
+  _container.querySelector('#ga-empty').style.display = 'flex';
+  _container.querySelector('#ga-empty').textContent  = 'Loading…';
+  _container.querySelector('#ga-jump-row').style.display   = 'none';
+  _container.querySelector('#ga-legend-row').style.display = 'none';
+  _container.querySelector('#ga-footer').style.display     = 'none';
+  showError(false);
+
+  await loadGenes();
+}
+
+async function loadGenes() {
+  const GENE_COLS = 'id,locus_tag,gene_name,gene_symbol,product,functional_category,sort_index,is_characterized';
+
+  const [refRes, cmpRes] = await Promise.all([
+    sb.from('genes')
+      .select(GENE_COLS)
+      .eq('strain_id', _refStrainId)
+      .lt('sort_index', 871)
+      .order('sort_index'),
+    sb.from('genes')
+      .select(GENE_COLS)
+      .eq('strain_id', _cmpStrainId)
+      .lt('sort_index', 871)
+      .order('sort_index'),
+  ]);
+
+  if (refRes.error || cmpRes.error) {
+    showError(true);
+    _container.querySelector('#ga-empty').textContent = 'Select two genomes above to begin.';
+    return;
+  }
+
+  _refGenes = refRes.data ?? [];
+  _cmpGenes = cmpRes.data ?? [];
+
+  // Build cmpGeneMap for O(1) lookup
+  _cmpGeneMap = new Map(_cmpGenes.map(g => [g.id, g]));
+
+  // Fetch orthologs for this strain pair (both directions)
+  const [o1, o2] = await Promise.all([
+    sb.from('orthologs')
+      .select('gene_id_a,gene_id_b')
+      .eq('strain_id_a', _refStrainId)
+      .eq('strain_id_b', _cmpStrainId),
+    sb.from('orthologs')
+      .select('gene_id_a,gene_id_b')
+      .eq('strain_id_a', _cmpStrainId)
+      .eq('strain_id_b', _refStrainId),
+  ]);
+
+  _orthologMap = new Map();
+  const cmpIdSet = new Set(_cmpGenes.map(g => g.id));
+  const refIdSet = new Set(_refGenes.map(g => g.id));
+
+  for (const row of (o1.data ?? [])) {
+    if (refIdSet.has(row.gene_id_a) && cmpIdSet.has(row.gene_id_b)) {
+      _orthologMap.set(row.gene_id_a, row.gene_id_b);
+    }
+  }
+  for (const row of (o2.data ?? [])) {
+    if (refIdSet.has(row.gene_id_b) && cmpIdSet.has(row.gene_id_a)) {
+      _orthologMap.set(row.gene_id_b, row.gene_id_a);
+    }
+  }
+
+  // Ready to render
+  buildJumpChips();
+  buildLegend();
+  _container.querySelector('#ga-empty').style.display = 'none';
+  _container.querySelector('#ga-list').style.display  = 'block';
+  _container.querySelector('#ga-footer').style.display = 'block';
+  appendPage();
+  setupObserver();
+}
+
+// ── Search (stub — replaced in Task 6) ───────────────────────
 function onSearch() {}

--- a/web/js/views/genome-alignment.js
+++ b/web/js/views/genome-alignment.js
@@ -457,6 +457,15 @@ function appendPage() {
   const cmpCol = _container.querySelector('#ga-cmp-col');
   const svgEl  = _container.querySelector('#ga-svg');
 
+  // Inject sticky column subheaders on first render
+  if (start === 0) {
+    const subheadStyle = 'position:sticky;top:0;z-index:5;padding:5px 9px;font-size:8.5px;font-weight:700;letter-spacing:0.06em;text-transform:uppercase;border-bottom:1px solid;';
+    refCol.insertAdjacentHTML('afterbegin',
+      `<div style="${subheadStyle}background:#eff6ff;color:#3b82f6;border-color:#dbeafe;">Reference ↓</div>`);
+    cmpCol.insertAdjacentHTML('afterbegin',
+      `<div style="${subheadStyle}background:#fffbeb;color:#d97706;border-color:#fde68a;">Comparison ↓</div>`);
+  }
+
   for (let i = start; i < end; i++) {
     const refGene   = _refGenes[i];
     const cmpGeneId = _orthologMap.get(refGene.id) ?? null;
@@ -469,9 +478,8 @@ function appendPage() {
     const y = i * ROW_HEIGHT + ROW_HEIGHT / 2;
     if (cmpGene) {
       svgEl.insertAdjacentHTML('beforeend',
-        `<path data-ref-id="${refGene.id}" d="M 0,${y} C 36,${y} 36,${y} 72,${y}"` +
-        ` stroke="${catColor}" stroke-width="${refGene.gene_name ? 9 : 7}"` +
-        ` fill="none" opacity="0.55"/>`);
+        `<line data-ref-id="${refGene.id}" x1="0" y1="${y}" x2="72" y2="${y}"` +
+        ` stroke="${catColor}" stroke-width="1.5" opacity="0.65"/>`);
     } else {
       svgEl.insertAdjacentHTML('beforeend',
         `<circle data-ref-id="${refGene.id}" cx="36" cy="${y}" r="4"` +
@@ -578,8 +586,8 @@ function toggleExpand(rowEl, gene, catColor, isRef) {
   // Highlight ribbon path
   const svgEl = _container.querySelector('#ga-svg');
   svgEl.querySelectorAll(`[data-ref-id="${refId}"]`).forEach(el => {
-    el.setAttribute('stroke-width', '14');
-    el.setAttribute('opacity', '0.85');
+    el.setAttribute('stroke-width', '3');
+    el.setAttribute('opacity', '0.9');
   });
 }
 
@@ -645,11 +653,9 @@ function collapseExpanded() {
 
   // Restore ribbon
   const svgEl = _container.querySelector('#ga-svg');
-  const refGene = _refGenes.find(g => g.id === _expandedRefId);
-  const strokeW = refGene?.gene_name ? 9 : 7;
   svgEl.querySelectorAll(`[data-ref-id="${_expandedRefId}"]`).forEach(el => {
-    el.setAttribute('stroke-width', String(strokeW));
-    el.setAttribute('opacity', '0.55');
+    el.setAttribute('stroke-width', '1.5');
+    el.setAttribute('opacity', '0.65');
   });
 
   _expandedRefId = null;

--- a/web/js/views/genome-alignment.js
+++ b/web/js/views/genome-alignment.js
@@ -63,6 +63,12 @@ const FUNC_LABELS = {
   'Unknown':                    'Unknown',
 };
 
+const STRAIN_ICONS = {
+  'CT-L2': '/design/icons_transparent/L2icon_transparent.png',
+  'CT-D':  '/design/icons_transparent/CTDicon_transparent.png',
+  'CM':    '/design/icons_transparent/CMicon_transparent.png',
+};
+
 const ROW_HEIGHT = 22; // px — fixed row height for ribbon Y calculation
 const PAGE_SIZE  = 100;
 
@@ -203,7 +209,7 @@ async function loadStrains() {
   const cmpPicker = _container.querySelector('#ga-cmp-picker');
 
   data.forEach(s => {
-    const label = `${s.emoji_icon ?? ''} ${s.common_name}`.trim();
+    const label = s.common_name;
     refPicker.insertAdjacentHTML('beforeend',
       `<option value="${s.id}">${label}</option>`);
     cmpPicker.insertAdjacentHTML('beforeend',
@@ -212,6 +218,28 @@ async function loadStrains() {
 
   refPicker.addEventListener('change', onPickerChange);
   cmpPicker.addEventListener('change', onPickerChange);
+}
+
+function updatePickerDisplay(pickerId, iconElId, strainId) {
+  const strain  = _strains.find(s => s.id === strainId);
+  const picker  = _container.querySelector(`#${pickerId}`);
+  const iconEl  = _container.querySelector(`#${iconElId}`);
+  if (!strain || !picker || !iconEl) return;
+
+  const color   = strain.color_hex ?? '#374151';
+  const iconSrc = STRAIN_ICONS[strain.common_name] ?? '';
+
+  picker.style.borderColor = color;
+  picker.style.color       = color;
+  // Make room for icon when one exists
+  picker.style.paddingLeft = iconSrc ? '30px' : '10px';
+
+  if (iconSrc) {
+    iconEl.src           = iconSrc;
+    iconEl.style.display = '';
+  } else {
+    iconEl.style.display = 'none';
+  }
 }
 
 function showError(visible) {
@@ -227,9 +255,12 @@ async function onPickerChange() {
   const refId = _container.querySelector('#ga-ref-picker').value;
   const cmpId = _container.querySelector('#ga-cmp-picker').value;
 
+  if (refId) updatePickerDisplay('ga-ref-picker', 'ga-ref-icon', refId);
+  if (cmpId) updatePickerDisplay('ga-cmp-picker', 'ga-cmp-icon', cmpId);
+
   if (!refId || !cmpId) return;
 
-  if (refId === cmpId) {
+  if (refId === cmpId && refId !== '') {
     showWarning(true);
     return;
   }

--- a/web/js/views/genome-alignment.js
+++ b/web/js/views/genome-alignment.js
@@ -1,6 +1,205 @@
 // ChlamAtlas — Genome Alignment tool
 import { sb } from '../client.js?v=80';
 
-export function renderGenomeAlignment(container) {
-  container.innerHTML = '<p style="padding:24px;color:#6b7280;">Loading…</p>';
+// ── Constants (copied from genomes.js) ───────────────────────
+const CATEGORY_COLORS = {
+  'Amino acid metabolism':      '#E66729',
+  'Cell envelope':              '#00A69D',
+  'Cell processes':             '#0052A3',
+  'Cofactor metabolism':        '#838FC7',
+  'Energy metabolism':          '#EC1C24',
+  'Inclusion membrane protein': '#E4B47E',
+  'Inermediary metabolism':     '#9D270E',
+  'Lipid metabolism':           '#6F2D90',
+  'Membrane transport':         '#6DCFF5',
+  'Nucleotide metabolism':      '#F497AE',
+  'Other':                      '#EBEBEB',
+  'Replication':                '#FFF100',
+  'Secreted effector':          '#00A551',
+  'Transcription':              '#FCB814',
+  'Translation':                '#BED630',
+  'Type III secretion':         '#8A5D3B',
+  'Unknown':                    '#AAAAAA',
+};
+const CATEGORY_COLOR_DEFAULT = '#E5E7EB';
+
+const CATEGORY_BADGE = {
+  'Amino acid metabolism':      { bg:'#fff3ed', text:'#9a3412', border:'#fed7aa' },
+  'Cell envelope':              { bg:'#f0fdfa', text:'#134e4a', border:'#99f6e4' },
+  'Cell processes':             { bg:'#eff6ff', text:'#1e3a8a', border:'#bfdbfe' },
+  'Cofactor metabolism':        { bg:'#f5f3ff', text:'#4c1d95', border:'#ddd6fe' },
+  'Energy metabolism':          { bg:'#fef2f2', text:'#991b1b', border:'#fecaca' },
+  'Inclusion membrane protein': { bg:'#fef9ee', text:'#a37742', border:'#f0d898' },
+  'Inermediary metabolism':     { bg:'#fef2f2', text:'#7f1d1d', border:'#fecaca' },
+  'Lipid metabolism':           { bg:'#faf5ff', text:'#581c87', border:'#e9d5ff' },
+  'Membrane transport':         { bg:'#f0f9ff', text:'#0c4a6e', border:'#bae6fd' },
+  'Nucleotide metabolism':      { bg:'#fdf2f8', text:'#831843', border:'#fbcfe8' },
+  'Other':                      { bg:'#f9fafb', text:'#6b7280', border:'#e5e7eb' },
+  'Replication':                { bg:'#fefce8', text:'#713f12', border:'#fde68a' },
+  'Secreted effector':          { bg:'#f0fdf4', text:'#14532d', border:'#86efac' },
+  'Transcription':              { bg:'#fffbeb', text:'#78350f', border:'#fde68a' },
+  'Translation':                { bg:'#f7fee7', text:'#365314', border:'#d9f99d' },
+  'Type III secretion':         { bg:'#fdf4ef', text:'#5c3317', border:'#e8c9b3' },
+  'Unknown':                    { bg:'#f9fafb', text:'#6b7280', border:'#e5e7eb' },
+};
+
+const FUNC_LABELS = {
+  'Amino acid metabolism':      'Amino acid',
+  'Cell envelope':              'Cell envelope',
+  'Cell processes':             'Cell processes',
+  'Cofactor metabolism':        'Cofactor',
+  'Energy metabolism':          'Energy',
+  'Inclusion membrane protein': 'Inc',
+  'Inermediary metabolism':     'Intermediary',
+  'Lipid metabolism':           'Lipid',
+  'Membrane transport':         'Transport',
+  'Nucleotide metabolism':      'Nucleotide',
+  'Other':                      'Other',
+  'Replication':                'Replication',
+  'Secreted effector':          'Secreted effector',
+  'Transcription':              'Transcription',
+  'Translation':                'Translation',
+  'Type III secretion':         'T3SS',
+  'Unknown':                    'Unknown',
+};
+
+const ROW_HEIGHT = 22; // px — fixed row height for ribbon Y calculation
+const PAGE_SIZE  = 100;
+
+// ── Module state (reset on each renderGenomeAlignment call) ──
+let _strains      = [];        // [{id, common_name, color_hex, emoji_icon}, ...]
+let _refStrainId  = null;
+let _cmpStrainId  = null;
+let _refGenes     = [];        // ordered by sort_index
+let _cmpGenes     = [];
+let _orthologMap  = new Map(); // refGeneId → cmpGeneId
+let _cmpGeneMap   = new Map(); // cmpGeneId → gene object
+let _renderedCount = 0;
+let _expandedRefId = null;     // currently expanded reference gene id
+let _observer     = null;      // IntersectionObserver for pagination
+let _container    = null;      // root container div
+
+// ── Entry point ──────────────────────────────────────────────
+export async function renderGenomeAlignment(container) {
+  _container    = container;
+  _strains      = [];
+  _refStrainId  = null;
+  _cmpStrainId  = null;
+  _refGenes     = [];
+  _cmpGenes     = [];
+  _orthologMap  = new Map();
+  _cmpGeneMap   = new Map();
+  _renderedCount = 0;
+  _expandedRefId = null;
+  if (_observer) { _observer.disconnect(); _observer = null; }
+
+  container.innerHTML = `
+    <div id="ga-wrap" style="display:flex;flex-direction:column;height:calc(100vh - 56px);font-family:system-ui,sans-serif;">
+
+      <!-- Sticky top bar -->
+      <div id="ga-topbar" style="position:sticky;top:0;z-index:10;background:#fff;border-bottom:1px solid #e2e8f0;flex-shrink:0;">
+
+        <!-- Row 1: strain pickers + search -->
+        <div style="display:flex;align-items:center;gap:8px;padding:8px 12px;flex-wrap:wrap;">
+          <select id="ga-ref-picker" style="border:1.5px solid #3b82f6;border-radius:6px;padding:4px 8px;font-size:12px;font-weight:600;color:#1d4ed8;background:#fff;cursor:pointer;">
+            <option value="">Reference genome…</option>
+          </select>
+          <span style="color:#94a3b8;font-size:16px;flex-shrink:0;">⇄</span>
+          <select id="ga-cmp-picker" style="border:1.5px solid #d97706;border-radius:6px;padding:4px 8px;font-size:12px;font-weight:600;color:#b45309;background:#fff;cursor:pointer;">
+            <option value="">Comparison genome…</option>
+          </select>
+          <input id="ga-search" placeholder="🔍 Search gene…" style="margin-left:auto;border:1px solid #e2e8f0;border-radius:6px;padding:4px 10px;font-size:12px;color:#374151;width:180px;outline:none;">
+        </div>
+
+        <!-- Row 2: jump chips (populated after gene load) -->
+        <div id="ga-jump-row" style="display:none;align-items:center;gap:5px;padding:3px 12px 4px;flex-wrap:wrap;font-size:10px;">
+          <span style="color:#94a3b8;font-weight:700;flex-shrink:0;letter-spacing:0.05em;">JUMP TO:</span>
+          <div id="ga-jump-chips" style="display:flex;gap:4px;flex-wrap:wrap;"></div>
+        </div>
+
+        <!-- Row 3: category legend (populated after gene load) -->
+        <div id="ga-legend-row" style="display:none;align-items:center;gap:6px;padding:3px 12px 5px;flex-wrap:wrap;font-size:9px;"></div>
+
+        <!-- Warning banner (same strain) -->
+        <div id="ga-warning" style="display:none;padding:4px 12px;background:#fef9c3;color:#854d0e;font-size:11px;border-top:1px solid #fde68a;">
+          ⚠️ Select two different genomes to compare.
+        </div>
+
+        <!-- Error banner -->
+        <div id="ga-error" style="display:none;padding:6px 12px;background:#fef2f2;color:#991b1b;font-size:11px;border-top:1px solid #fecaca;">
+          Failed to load genome data.
+          <button id="ga-retry" style="margin-left:8px;font-size:11px;color:#1d4ed8;background:none;border:none;cursor:pointer;text-decoration:underline;">Retry</button>
+        </div>
+      </div>
+
+      <!-- Empty state -->
+      <div id="ga-empty" style="display:flex;align-items:center;justify-content:center;flex:1;color:#94a3b8;font-size:14px;">
+        Select two genomes above to begin.
+      </div>
+
+      <!-- Gene list (hidden until data loaded) -->
+      <div id="ga-list" style="display:none;flex:1;overflow-y:auto;">
+        <div id="ga-columns" style="display:flex;min-height:100%;">
+          <div id="ga-ref-col" style="width:38%;border-right:1px solid #f0f0f0;"></div>
+          <div id="ga-ribbon-col" style="width:24%;position:relative;overflow:visible;">
+            <svg id="ga-svg" width="100%" height="0"
+              viewBox="0 0 100 0"
+              preserveAspectRatio="none"
+              style="position:absolute;top:0;left:0;pointer-events:none;"></svg>
+          </div>
+          <div id="ga-cmp-col" style="width:38%;border-left:1px solid #f0f0f0;"></div>
+        </div>
+        <div id="ga-sentinel" style="height:1px;"></div>
+        <div id="ga-footer" style="display:none;padding:6px 12px;font-size:10px;color:#9ca3af;text-align:center;">
+          Plasmid genes excluded from this view.
+        </div>
+      </div>
+
+    </div>
+  `;
+
+  await loadStrains();
+}
+
+// ── Strain loading ───────────────────────────────────────────
+async function loadStrains() {
+  const { data, error } = await sb
+    .from('strains')
+    .select('id,common_name,color_hex,emoji_icon')
+    .eq('is_active', true)
+    .order('common_name');
+
+  if (error || !data?.length) {
+    showError(true);
+    return;
+  }
+
+  _strains = data;
+  const refPicker = _container.querySelector('#ga-ref-picker');
+  const cmpPicker = _container.querySelector('#ga-cmp-picker');
+
+  data.forEach(s => {
+    const label = `${s.emoji_icon ?? ''} ${s.common_name}`.trim();
+    refPicker.insertAdjacentHTML('beforeend',
+      `<option value="${s.id}">${label}</option>`);
+    cmpPicker.insertAdjacentHTML('beforeend',
+      `<option value="${s.id}">${label}</option>`);
+  });
+
+  refPicker.addEventListener('change', onPickerChange);
+  cmpPicker.addEventListener('change', onPickerChange);
+
+  _container.querySelector('#ga-retry')?.addEventListener('click', () => {
+    showError(false);
+    onPickerChange();
+  });
+  _container.querySelector('#ga-search')?.addEventListener('input', onSearch);
+}
+
+function showError(visible) {
+  _container.querySelector('#ga-error').style.display = visible ? 'block' : 'none';
+}
+
+function showWarning(visible) {
+  _container.querySelector('#ga-warning').style.display = visible ? 'block' : 'none';
 }

--- a/web/js/views/genome-alignment.js
+++ b/web/js/views/genome-alignment.js
@@ -496,3 +496,21 @@ function setupObserver() {
 
   _observer.observe(sentinel);
 }
+
+// ── Legend ───────────────────────────────────────────────────
+function buildLegend() {
+  const legendRow = _container.querySelector('#ga-legend-row');
+  legendRow.innerHTML = '';
+
+  Object.entries(FUNC_LABELS).forEach(([cat, label]) => {
+    const color = CATEGORY_COLORS[cat] ?? CATEGORY_COLOR_DEFAULT;
+    const item  = document.createElement('span');
+    item.style.cssText = 'display:flex;align-items:center;gap:3px;white-space:nowrap;';
+    item.innerHTML =
+      `<span style="width:8px;height:8px;border-radius:2px;background:${color};flex-shrink:0;display:inline-block;"></span>` +
+      `<span style="color:#6b7280;">${label}</span>`;
+    legendRow.appendChild(item);
+  });
+
+  legendRow.style.display = 'flex';
+}

--- a/web/js/views/genome-alignment.js
+++ b/web/js/views/genome-alignment.js
@@ -79,6 +79,7 @@ let _renderedCount = 0;
 let _expandedRefId = null;     // currently expanded reference gene id
 let _observer     = null;      // IntersectionObserver for pagination
 let _container    = null;      // root container div
+let _closePickersListener = null; // document click handler for custom pickers
 
 // ── Entry point ──────────────────────────────────────────────
 export async function renderGenomeAlignment(container) {
@@ -93,67 +94,79 @@ export async function renderGenomeAlignment(container) {
   _renderedCount = 0;
   _expandedRefId = null;
   if (_observer) { _observer.disconnect(); _observer = null; }
+  if (_closePickersListener) {
+    document.removeEventListener('click', _closePickersListener);
+    _closePickersListener = null;
+  }
 
   container.innerHTML = `
-    <div id="ga-wrap" style="display:flex;flex-direction:column;height:calc(100vh - 56px);font-family:system-ui,sans-serif;">
+    <div id="ga-wrap" style="display:flex;height:calc(100vh - 56px);font-family:system-ui,sans-serif;background:#fff;overflow:hidden;">
 
-      <!-- Sticky top bar -->
-      <div id="ga-topbar" style="position:sticky;top:0;z-index:10;background:#fff;border-bottom:1px solid #e2e8f0;flex-shrink:0;">
+      <!-- Left sidebar: Jump chips -->
+      <div id="ga-sidebar-left" style="width:88px;flex-shrink:0;position:sticky;top:0;height:calc(100vh - 56px);display:flex;flex-direction:column;align-items:center;padding:24px 8px 16px;overflow-y:auto;border-right:1px solid #f0f4f8;">
+        <div style="font-size:8px;font-weight:700;letter-spacing:0.1em;color:#94a3b8;text-transform:uppercase;margin-bottom:10px;">Jump to</div>
+        <div id="ga-jump-chips" style="display:flex;flex-direction:column;width:100%;gap:4px;"></div>
+      </div>
 
-        <!-- Row 1: strain pickers + search -->
-        <div style="display:flex;align-items:center;gap:8px;padding:8px 12px;flex-wrap:wrap;">
-          <select id="ga-ref-picker" style="border:1.5px solid #3b82f6;border-radius:6px;padding:4px 8px;font-size:12px;font-weight:600;color:#1d4ed8;background:#fff;cursor:pointer;">
-            <option value="">Reference genome…</option>
-          </select>
+      <!-- Center column -->
+      <div style="flex:1;min-width:0;display:flex;flex-direction:column;overflow:hidden;">
+
+        <!-- Sticky picker row -->
+        <div id="ga-picker-row" style="position:sticky;top:0;z-index:10;background:#fff;border-bottom:1px solid #e2e8f0;flex-shrink:0;padding:10px 16px;display:flex;align-items:center;justify-content:center;gap:10px;flex-wrap:wrap;">
+          <div style="position:relative;display:inline-flex;align-items:center;flex-shrink:0;">
+            <img id="ga-ref-icon" style="width:16px;height:16px;object-fit:contain;position:absolute;left:8px;z-index:1;pointer-events:none;display:none;">
+            <select id="ga-ref-picker" style="border:1.5px solid #e2e8f0;border-radius:6px;padding:5px 10px 5px 10px;font-size:12px;font-weight:600;color:#9ca3af;background:#fff;cursor:pointer;">
+              <option value="">Reference genome…</option>
+            </select>
+          </div>
           <span style="color:#94a3b8;font-size:16px;flex-shrink:0;">⇄</span>
-          <select id="ga-cmp-picker" style="border:1.5px solid #d97706;border-radius:6px;padding:4px 8px;font-size:12px;font-weight:600;color:#b45309;background:#fff;cursor:pointer;">
-            <option value="">Comparison genome…</option>
-          </select>
-          <input id="ga-search" placeholder="🔍 Search gene…" style="margin-left:auto;border:1px solid #e2e8f0;border-radius:6px;padding:4px 10px;font-size:12px;color:#374151;width:180px;outline:none;">
+          <div style="position:relative;display:inline-flex;align-items:center;flex-shrink:0;">
+            <img id="ga-cmp-icon" style="width:16px;height:16px;object-fit:contain;position:absolute;left:8px;z-index:1;pointer-events:none;display:none;">
+            <select id="ga-cmp-picker" style="border:1.5px solid #e2e8f0;border-radius:6px;padding:5px 10px 5px 10px;font-size:12px;font-weight:600;color:#9ca3af;background:#fff;cursor:pointer;">
+              <option value="">Comparison genome…</option>
+            </select>
+          </div>
+          <input id="ga-search" placeholder="🔍 Search gene…" style="border:1px solid #e2e8f0;border-radius:6px;padding:5px 10px;font-size:12px;color:#374151;width:170px;outline:none;background:#f8fafc;">
         </div>
-
-        <!-- Row 2: jump chips (populated after gene load) -->
-        <div id="ga-jump-row" style="display:none;align-items:center;gap:5px;padding:3px 12px 4px;flex-wrap:wrap;font-size:10px;">
-          <span style="color:#94a3b8;font-weight:700;flex-shrink:0;letter-spacing:0.05em;">JUMP TO:</span>
-          <div id="ga-jump-chips" style="display:flex;gap:4px;flex-wrap:wrap;"></div>
-        </div>
-
-        <!-- Row 3: category legend (populated after gene load) -->
-        <div id="ga-legend-row" style="display:none;align-items:center;gap:6px;padding:3px 12px 5px;flex-wrap:wrap;font-size:9px;"></div>
 
         <!-- Warning banner (same strain) -->
-        <div id="ga-warning" style="display:none;padding:4px 12px;background:#fef9c3;color:#854d0e;font-size:11px;border-top:1px solid #fde68a;">
+        <div id="ga-warning" style="display:none;padding:4px 16px;background:#fef9c3;color:#854d0e;font-size:11px;border-bottom:1px solid #fde68a;">
           ⚠️ Select two different genomes to compare.
         </div>
 
         <!-- Error banner -->
-        <div id="ga-error" style="display:none;padding:6px 12px;background:#fef2f2;color:#991b1b;font-size:11px;border-top:1px solid #fecaca;">
+        <div id="ga-error" style="display:none;padding:6px 16px;background:#fef2f2;color:#991b1b;font-size:11px;border-bottom:1px solid #fecaca;">
           Failed to load genome data.
           <button id="ga-retry" style="margin-left:8px;font-size:11px;color:#1d4ed8;background:none;border:none;cursor:pointer;text-decoration:underline;">Retry</button>
         </div>
-      </div>
 
-      <!-- Empty state -->
-      <div id="ga-empty" style="display:flex;align-items:center;justify-content:center;flex:1;color:#94a3b8;font-size:14px;">
-        Select two genomes above to begin.
-      </div>
+        <!-- Empty state -->
+        <div id="ga-empty" style="display:flex;align-items:center;justify-content:center;flex:1;color:#94a3b8;font-size:14px;">
+          Select two genomes above to begin.
+        </div>
 
-      <!-- Gene list (hidden until data loaded) -->
-      <div id="ga-list" style="display:none;flex:1;overflow-y:auto;">
-        <div id="ga-columns" style="display:flex;min-height:100%;">
-          <div id="ga-ref-col" style="width:38%;border-right:1px solid #f0f0f0;"></div>
-          <div id="ga-ribbon-col" style="width:24%;position:relative;overflow:visible;">
-            <svg id="ga-svg" width="100%" height="0"
-              viewBox="0 0 100 0"
-              preserveAspectRatio="none"
-              style="position:absolute;top:0;left:0;pointer-events:none;"></svg>
+        <!-- Gene list -->
+        <div id="ga-list" style="display:none;flex:1;overflow-y:auto;padding:16px 0 24px;">
+          <div style="max-width:680px;margin:0 auto;display:flex;border-radius:6px;overflow:hidden;box-shadow:0 1px 4px rgba(0,0,0,0.07),0 0 0 1px #e2e8f0;">
+            <div id="ga-ref-col" style="flex:1;min-width:0;"></div>
+            <div id="ga-ribbon-col" style="width:72px;flex-shrink:0;position:relative;background:#fafafa;border-left:1px solid #ececec;border-right:1px solid #ececec;">
+              <svg id="ga-svg" width="72" height="0" viewBox="0 0 72 0"
+                style="position:absolute;top:0;left:0;pointer-events:none;"></svg>
+            </div>
+            <div id="ga-cmp-col" style="flex:1;min-width:0;"></div>
           </div>
-          <div id="ga-cmp-col" style="width:38%;border-left:1px solid #f0f0f0;"></div>
+          <div id="ga-sentinel" style="height:1px;"></div>
+          <div id="ga-footer" style="display:none;padding:6px 12px;font-size:10px;color:#9ca3af;text-align:center;">
+            Plasmid genes excluded from this view.
+          </div>
         </div>
-        <div id="ga-sentinel" style="height:1px;"></div>
-        <div id="ga-footer" style="display:none;padding:6px 12px;font-size:10px;color:#9ca3af;text-align:center;">
-          Plasmid genes excluded from this view.
-        </div>
+
+      </div>
+
+      <!-- Right sidebar: Legend -->
+      <div id="ga-sidebar-right" style="width:110px;flex-shrink:0;position:sticky;top:0;height:calc(100vh - 56px);display:flex;flex-direction:column;padding:24px 10px 16px;overflow-y:auto;border-left:1px solid #f0f4f8;">
+        <div style="font-size:8px;font-weight:700;letter-spacing:0.1em;color:#94a3b8;text-transform:uppercase;margin-bottom:10px;text-align:center;">Key</div>
+        <div id="ga-legend-row"></div>
       </div>
 
     </div>
@@ -234,12 +247,11 @@ async function onPickerChange() {
   _container.querySelector('#ga-cmp-col').innerHTML  = '';
   _container.querySelector('#ga-svg').innerHTML      = '';
   _container.querySelector('#ga-svg').setAttribute('height', '0');
-  _container.querySelector('#ga-svg').setAttribute('viewBox', '0 0 100 0');
+  _container.querySelector('#ga-svg').setAttribute('viewBox', '0 0 72 0');
   _container.querySelector('#ga-list').style.display = 'none';
   _container.querySelector('#ga-empty').style.display = 'flex';
   _container.querySelector('#ga-empty').textContent  = 'Loading…';
-  _container.querySelector('#ga-jump-row').style.display   = 'none';
-  _container.querySelector('#ga-legend-row').style.display = 'none';
+  _container.querySelector('#ga-legend-row').innerHTML = '';
   _container.querySelector('#ga-footer').style.display     = 'none';
   showError(false);
 
@@ -326,7 +338,6 @@ async function loadGenes() {
 function buildJumpChips() {
   if (!_refGenes.length) return;
   const chipsEl = _container.querySelector('#ga-jump-chips');
-  const jumpRow = _container.querySelector('#ga-jump-row');
   chipsEl.innerHTML = '';
 
   const indices = [];
@@ -358,7 +369,7 @@ function buildJumpChips() {
     chipsEl.appendChild(btn);
   });
 
-  jumpRow.style.display = 'flex';
+  // chips are always visible in the left sidebar — no show/hide needed
 }
 
 function jumpToIndex(targetIdx) {
@@ -413,12 +424,12 @@ function appendPage() {
     const y = i * ROW_HEIGHT + ROW_HEIGHT / 2;
     if (cmpGene) {
       svgEl.insertAdjacentHTML('beforeend',
-        `<path data-ref-id="${refGene.id}" d="M 0,${y} C 50,${y} 50,${y} 100,${y}"` +
+        `<path data-ref-id="${refGene.id}" d="M 0,${y} C 36,${y} 36,${y} 72,${y}"` +
         ` stroke="${catColor}" stroke-width="${refGene.gene_name ? 9 : 7}"` +
         ` fill="none" opacity="0.55"/>`);
     } else {
       svgEl.insertAdjacentHTML('beforeend',
-        `<circle data-ref-id="${refGene.id}" cx="50" cy="${y}" r="4"` +
+        `<circle data-ref-id="${refGene.id}" cx="36" cy="${y}" r="4"` +
         ` fill="#fca5a5" opacity="0.8"/>`);
     }
   }
@@ -426,7 +437,7 @@ function appendPage() {
   _renderedCount = end;
   const totalH = _renderedCount * ROW_HEIGHT;
   svgEl.setAttribute('height', totalH);
-  svgEl.setAttribute('viewBox', `0 0 100 ${totalH}`);
+  svgEl.setAttribute('viewBox', `0 0 72 ${totalH}`);
 }
 
 function buildRow(gene, catColor, isRef, refId = null) {
@@ -642,5 +653,5 @@ function buildLegend() {
     legendRow.appendChild(item);
   });
 
-  legendRow.style.display = 'flex';
+  // ga-legend-row is always visible in the right sidebar — no display toggle needed
 }

--- a/web/js/views/genome-alignment.js
+++ b/web/js/views/genome-alignment.js
@@ -305,8 +305,73 @@ async function loadGenes() {
   setupObserver();
 }
 
-// ── Search (stub — replaced in Task 6) ───────────────────────
-function onSearch() {}
+// ── Navigation ───────────────────────────────────────────────
+function buildJumpChips() {
+  const chipsEl = _container.querySelector('#ga-jump-chips');
+  const jumpRow = _container.querySelector('#ga-jump-row');
+  chipsEl.innerHTML = '';
+
+  const indices = [];
+  for (let i = 0; i < _refGenes.length; i += 100) indices.push(i);
+  // Always include the last gene
+  if (indices[indices.length - 1] !== _refGenes.length - 1) {
+    indices.push(_refGenes.length - 1);
+  }
+
+  indices.forEach(idx => {
+    const gene  = _refGenes[idx];
+    const label = idx === _refGenes.length - 1
+      ? `${gene.locus_tag} (end)`
+      : gene.locus_tag;
+
+    const btn = document.createElement('button');
+    btn.textContent = label;
+    btn.style.cssText = [
+      'background:#f1f5f9',
+      'border:1px solid #e2e8f0',
+      'border-radius:4px',
+      'padding:2px 7px',
+      'font-size:9px',
+      'color:#475569',
+      'cursor:pointer',
+      'font-family:monospace',
+    ].join(';');
+    btn.addEventListener('click', () => jumpToIndex(idx));
+    chipsEl.appendChild(btn);
+  });
+
+  jumpRow.style.display = 'flex';
+}
+
+function jumpToIndex(targetIdx) {
+  // Render all pages up to and including the target
+  while (_renderedCount <= targetIdx && _renderedCount < _refGenes.length) {
+    appendPage();
+  }
+  // Scroll the target row into view
+  const refCol = _container.querySelector('#ga-ref-col');
+  const rows   = refCol.querySelectorAll('.ga-row');
+  const row    = rows[targetIdx];
+  if (row) {
+    row.scrollIntoView({ block: 'start', behavior: 'smooth' });
+    row.style.outline = '2px solid #3b82f6';
+    setTimeout(() => { row.style.outline = ''; }, 1500);
+  }
+}
+
+function onSearch(e) {
+  const query = e.target.value.trim().toLowerCase();
+  if (!query) return;
+
+  const idx = _refGenes.findIndex(g =>
+    g.locus_tag?.toLowerCase().includes(query) ||
+    g.gene_name?.toLowerCase().includes(query) ||
+    g.gene_symbol?.toLowerCase().includes(query)
+  );
+  if (idx === -1) return;
+
+  jumpToIndex(idx);
+}
 
 // ── Rendering ────────────────────────────────────────────────
 function appendPage() {

--- a/web/js/views/genome-alignment.js
+++ b/web/js/views/genome-alignment.js
@@ -511,7 +511,8 @@ function toggleExpand(rowEl, gene, catColor, isRef) {
   const refRow     = refCol.querySelector(`.ga-row[data-ref-id="${refId}"]`);
   const cmpRow     = cmpCol.querySelector(`.ga-row[data-ref-id="${refId}"]`);
 
-  if (refRow) expandRowEl(refRow, gene, catColor, true);
+  const refGene = _refGenes.find(g => g.id === refId) ?? gene;
+  if (refRow) expandRowEl(refRow, refGene, catColor, true);
   if (cmpRow) {
     const cmpGeneId = _orthologMap.get(refId);
     const cmpGene   = cmpGeneId ? _cmpGeneMap.get(cmpGeneId) : null;

--- a/web/js/views/genome-alignment.js
+++ b/web/js/views/genome-alignment.js
@@ -411,3 +411,23 @@ function buildGapRow() {
 function toggleExpand(rowEl, gene, catColor, isRef) {
   // stub — replaced in Task 8
 }
+
+// ── Pagination ───────────────────────────────────────────────
+function setupObserver() {
+  const sentinel = _container.querySelector('#ga-sentinel');
+  if (!sentinel) return;
+
+  _observer = new IntersectionObserver((entries) => {
+    if (!entries[0].isIntersecting) return;
+    if (_renderedCount >= _refGenes.length) {
+      _observer.disconnect();
+      return;
+    }
+    appendPage();
+  }, {
+    root: _container.querySelector('#ga-list'),
+    rootMargin: '200px',
+  });
+
+  _observer.observe(sentinel);
+}

--- a/web/js/views/genome-alignment.js
+++ b/web/js/views/genome-alignment.js
@@ -158,6 +158,12 @@ export async function renderGenomeAlignment(container) {
     </div>
   `;
 
+  _container.querySelector('#ga-retry')?.addEventListener('click', () => {
+    showError(false);
+    loadStrains();
+  });
+  _container.querySelector('#ga-search')?.addEventListener('input', onSearch);
+
   await loadStrains();
 }
 
@@ -188,12 +194,6 @@ async function loadStrains() {
 
   refPicker.addEventListener('change', onPickerChange);
   cmpPicker.addEventListener('change', onPickerChange);
-
-  _container.querySelector('#ga-retry')?.addEventListener('click', () => {
-    showError(false);
-    onPickerChange();
-  });
-  _container.querySelector('#ga-search')?.addEventListener('input', onSearch);
 }
 
 function showError(visible) {
@@ -203,3 +203,7 @@ function showError(visible) {
 function showWarning(visible) {
   _container.querySelector('#ga-warning').style.display = visible ? 'block' : 'none';
 }
+
+// stubs — replaced in Task 3 and Task 6
+function onPickerChange() {}
+function onSearch() {}

--- a/web/js/views/genome-alignment.js
+++ b/web/js/views/genome-alignment.js
@@ -1,0 +1,6 @@
+// ChlamAtlas — Genome Alignment tool
+import { sb } from '../client.js?v=80';
+
+export function renderGenomeAlignment(container) {
+  container.innerHTML = '<p style="padding:24px;color:#6b7280;">Loading…</p>';
+}

--- a/web/js/views/genome-alignment.js
+++ b/web/js/views/genome-alignment.js
@@ -686,17 +686,32 @@ function setupObserver() {
 // ── Legend ───────────────────────────────────────────────────
 function buildLegend() {
   const legendRow = _container.querySelector('#ga-legend-row');
+  if (!legendRow) return;
   legendRow.innerHTML = '';
 
   Object.entries(FUNC_LABELS).forEach(([cat, label]) => {
     const color = CATEGORY_COLORS[cat] ?? CATEGORY_COLOR_DEFAULT;
-    const item  = document.createElement('span');
-    item.style.cssText = 'display:flex;align-items:center;gap:3px;white-space:nowrap;';
+    const item  = document.createElement('div');
+    item.style.cssText = 'display:flex;align-items:center;gap:5px;font-size:8.5px;color:#64748b;padding:2.5px 0;';
     item.innerHTML =
-      `<span style="width:8px;height:8px;border-radius:2px;background:${color};flex-shrink:0;display:inline-block;"></span>` +
-      `<span style="color:#6b7280;">${label}</span>`;
+      `<span style="width:8px;height:8px;border-radius:50%;background:${color};flex-shrink:0;display:inline-block;` +
+      (color === '#FFF100' || color === '#EBEBEB' ? 'border:1px solid #ccc;' : '') +
+      `"></span>` +
+      `<span>${label}</span>`;
     legendRow.appendChild(item);
   });
 
-  // ga-legend-row is always visible in the right sidebar — no display toggle needed
+  // Connector legend
+  const connectorLegend = document.createElement('div');
+  connectorLegend.style.cssText = 'margin-top:12px;padding-top:10px;border-top:1px solid #e8edf2;';
+  connectorLegend.innerHTML =
+    `<div style="display:flex;align-items:center;gap:5px;font-size:8.5px;color:#64748b;padding:2.5px 0;">` +
+      `<svg width="20" height="4" style="flex-shrink:0"><line x1="0" y1="2" x2="20" y2="2" stroke="#888" stroke-width="1.5" opacity="0.6"/></svg>` +
+      `Ortholog` +
+    `</div>` +
+    `<div style="display:flex;align-items:center;gap:5px;font-size:8.5px;color:#64748b;padding:2.5px 0;margin-top:2px;">` +
+      `<svg width="20" height="10" style="flex-shrink:0"><circle cx="10" cy="5" r="3.5" fill="#fca5a5" opacity="0.85"/></svg>` +
+      `No ortholog` +
+    `</div>`;
+  legendRow.appendChild(connectorLegend);
 }

--- a/web/js/views/genome-alignment.js
+++ b/web/js/views/genome-alignment.js
@@ -147,7 +147,7 @@ export async function renderGenomeAlignment(container) {
 
         <!-- Gene list -->
         <div id="ga-list" style="display:none;flex:1;overflow-y:auto;padding:16px 0 24px;">
-          <div style="max-width:680px;margin:0 auto;display:flex;border-radius:6px;overflow:hidden;box-shadow:0 1px 4px rgba(0,0,0,0.07),0 0 0 1px #e2e8f0;">
+          <div style="max-width:680px;margin:0 auto;display:flex;border-radius:6px;box-shadow:0 1px 4px rgba(0,0,0,0.07),0 0 0 1px #e2e8f0;">
             <div id="ga-ref-col" style="flex:1;min-width:0;"></div>
             <div id="ga-ribbon-col" style="width:72px;flex-shrink:0;position:relative;background:#fafafa;border-left:1px solid #ececec;border-right:1px solid #ececec;">
               <svg id="ga-svg" width="72" height="0" viewBox="0 0 72 0"
@@ -164,7 +164,7 @@ export async function renderGenomeAlignment(container) {
       </div>
 
       <!-- Right sidebar: Legend -->
-      <div id="ga-sidebar-right" style="width:110px;flex-shrink:0;position:sticky;top:0;height:calc(100vh - 56px);display:flex;flex-direction:column;padding:24px 10px 16px;overflow-y:auto;border-left:1px solid #f0f4f8;">
+      <div id="ga-sidebar-right" style="width:110px;flex-shrink:0;position:sticky;top:0;height:calc(100vh - 56px);display:flex;flex-direction:column;padding:24px 10px 16px;overflow-y:auto;overflow-x:hidden;border-left:1px solid #f0f4f8;">
         <div style="font-size:8px;font-weight:700;letter-spacing:0.1em;color:#94a3b8;text-transform:uppercase;margin-bottom:10px;text-align:center;">Key</div>
         <div id="ga-legend-row"></div>
       </div>

--- a/web/js/views/genome-alignment.js
+++ b/web/js/views/genome-alignment.js
@@ -614,15 +614,15 @@ function expandRowEl(rowEl, gene, catColor, isRef) {
     'box-shadow:0 4px 12px rgba(0,0,0,0.08)',
   ].join(';');
 
+  const protId = `ga-prot-${gene.id}`;
   body.innerHTML = [
     product ? `<div style="font-size:10px;color:#374151;margin-bottom:4px;">${escHtml(product)}</div>` : '',
     `<span style="display:inline-block;font-size:9px;padding:2px 6px;border-radius:4px;` +
       `background:${badge.bg};color:${badge.text};border:1px solid ${badge.border};margin-bottom:4px;">` +
       `${escHtml(catName)}</span>`,
-    isRef
-      ? `<div style="margin-top:4px;"><a href="#" class="ga-detail-link" data-gene-id="${gene.id}" ` +
-        `style="font-size:10px;color:#3b82f6;text-decoration:none;">→ Gene detail</a></div>`
-      : '',
+    `<div id="${protId}" style="font-size:9px;color:#9ca3af;margin-top:2px;"></div>`,
+    `<div style="margin-top:4px;"><a href="#" class="ga-detail-link" data-gene-id="${gene.id}" ` +
+      `style="font-size:10px;color:#3b82f6;text-decoration:none;">→ Gene detail</a></div>`,
   ].join('');
 
   body.querySelector('.ga-detail-link')?.addEventListener('click', (e) => {
@@ -633,6 +633,20 @@ function expandRowEl(rowEl, gene, catColor, isRef) {
 
   rowEl.style.position = 'relative';
   rowEl.appendChild(body);
+
+  // Lazy-load protein size data
+  sb.from('proteins')
+    .select('mass_kd,length_aa')
+    .eq('gene_id', gene.id)
+    .maybeSingle()
+    .then(({ data }) => {
+      const el = body.querySelector(`#${protId}`);
+      if (!el || !data) return;
+      const parts = [];
+      if (data.length_aa) parts.push(`${data.length_aa} aa`);
+      if (data.mass_kd)   parts.push(`${data.mass_kd} kDa`);
+      if (parts.length) el.textContent = parts.join(' · ');
+    });
 }
 
 function collapseExpanded() {

--- a/web/js/views/genome-alignment.js
+++ b/web/js/views/genome-alignment.js
@@ -490,9 +490,120 @@ function buildGapRow() {
   return row;
 }
 
-// ── Expand / collapse (implemented in Task 8) ────────────────
+// ── Expand / collapse ────────────────────────────────────────
 function toggleExpand(rowEl, gene, catColor, isRef) {
-  // stub — replaced in Task 8
+  const refId = rowEl.dataset.refId;
+
+  // Collapse if clicking the already-expanded row
+  if (_expandedRefId === refId) {
+    collapseExpanded();
+    return;
+  }
+
+  // Collapse previous
+  if (_expandedRefId) collapseExpanded();
+
+  _expandedRefId = refId;
+
+  // Expand the ref row
+  const refCol     = _container.querySelector('#ga-ref-col');
+  const cmpCol     = _container.querySelector('#ga-cmp-col');
+  const refRow     = refCol.querySelector(`.ga-row[data-ref-id="${refId}"]`);
+  const cmpRow     = cmpCol.querySelector(`.ga-row[data-ref-id="${refId}"]`);
+
+  if (refRow) expandRowEl(refRow, gene, catColor, true);
+  if (cmpRow) {
+    const cmpGeneId = _orthologMap.get(refId);
+    const cmpGene   = cmpGeneId ? _cmpGeneMap.get(cmpGeneId) : null;
+    if (cmpGene) expandRowEl(cmpRow, cmpGene, catColor, false);
+  }
+
+  // Highlight ribbon path
+  const svgEl = _container.querySelector('#ga-svg');
+  svgEl.querySelectorAll(`[data-ref-id="${refId}"]`).forEach(el => {
+    el.setAttribute('stroke-width', '14');
+    el.setAttribute('opacity', '0.85');
+  });
+}
+
+function expandRowEl(rowEl, gene, catColor, isRef) {
+  rowEl.style.height   = 'auto';
+  rowEl.style.overflow = 'visible';
+
+  const badge   = CATEGORY_BADGE[gene.functional_category] ?? { bg:'#f9fafb', text:'#6b7280', border:'#e5e7eb' };
+  const catName = FUNC_LABELS[gene.functional_category] ?? gene.functional_category ?? 'Unknown';
+  const product = gene.product ?? '';
+
+  const body = document.createElement('div');
+  body.className = 'ga-expand-body';
+  body.style.cssText = [
+    'position:absolute',
+    `top:${ROW_HEIGHT}px`,
+    'left:-4px',
+    'right:0',
+    'z-index:20',
+    `background:${badge.bg}`,
+    `border:1.5px solid ${badge.border}`,
+    'border-top:none',
+    'padding:6px 8px 8px',
+    'box-shadow:0 4px 12px rgba(0,0,0,0.08)',
+  ].join(';');
+
+  body.innerHTML = [
+    product ? `<div style="font-size:10px;color:#374151;margin-bottom:4px;">${escHtml(product)}</div>` : '',
+    `<span style="display:inline-block;font-size:9px;padding:2px 6px;border-radius:4px;` +
+      `background:${badge.bg};color:${badge.text};border:1px solid ${badge.border};margin-bottom:4px;">` +
+      `${escHtml(catName)}</span>`,
+    isRef
+      ? `<div style="margin-top:4px;"><a href="#" class="ga-detail-link" data-gene-id="${gene.id}" ` +
+        `style="font-size:10px;color:#3b82f6;text-decoration:none;">→ Gene detail</a></div>`
+      : '',
+  ].join('');
+
+  body.querySelector('.ga-detail-link')?.addEventListener('click', (e) => {
+    e.preventDefault();
+    window.__openGeneId = gene.id;
+    window.dispatchEvent(new CustomEvent('chlamatlas:navigate', { detail: { tab: 'genomes' } }));
+  });
+
+  rowEl.style.position = 'relative';
+  rowEl.appendChild(body);
+}
+
+function collapseExpanded() {
+  if (!_expandedRefId) return;
+
+  const refCol = _container.querySelector('#ga-ref-col');
+  const cmpCol = _container.querySelector('#ga-cmp-col');
+
+  [refCol, cmpCol].forEach(col => {
+    const row  = col.querySelector(`.ga-row[data-ref-id="${_expandedRefId}"]`);
+    const body = row?.querySelector('.ga-expand-body');
+    if (body) body.remove();
+    if (row) {
+      row.style.height   = `${ROW_HEIGHT}px`;
+      row.style.overflow = 'hidden';
+    }
+  });
+
+  // Restore ribbon
+  const svgEl = _container.querySelector('#ga-svg');
+  const refGene = _refGenes.find(g => g.id === _expandedRefId);
+  const strokeW = refGene?.gene_name ? 9 : 7;
+  svgEl.querySelectorAll(`[data-ref-id="${_expandedRefId}"]`).forEach(el => {
+    el.setAttribute('stroke-width', String(strokeW));
+    el.setAttribute('opacity', '0.55');
+  });
+
+  _expandedRefId = null;
+}
+
+function escHtml(str) {
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
 }
 
 // ── Pagination ───────────────────────────────────────────────

--- a/web/js/views/genome-alignment.js
+++ b/web/js/views/genome-alignment.js
@@ -307,3 +307,107 @@ async function loadGenes() {
 
 // ── Search (stub — replaced in Task 6) ───────────────────────
 function onSearch() {}
+
+// ── Rendering ────────────────────────────────────────────────
+function appendPage() {
+  const start = _renderedCount;
+  const end   = Math.min(start + PAGE_SIZE, _refGenes.length);
+  if (start >= _refGenes.length) return;
+
+  const refCol = _container.querySelector('#ga-ref-col');
+  const cmpCol = _container.querySelector('#ga-cmp-col');
+  const svgEl  = _container.querySelector('#ga-svg');
+
+  for (let i = start; i < end; i++) {
+    const refGene   = _refGenes[i];
+    const cmpGeneId = _orthologMap.get(refGene.id) ?? null;
+    const cmpGene   = cmpGeneId ? _cmpGeneMap.get(cmpGeneId) : null;
+    const catColor  = CATEGORY_COLORS[refGene.functional_category] ?? CATEGORY_COLOR_DEFAULT;
+
+    refCol.appendChild(buildRow(refGene, catColor, true));
+    cmpCol.appendChild(cmpGene ? buildRow(cmpGene, catColor, false, refGene.id) : buildGapRow());
+
+    const y = i * ROW_HEIGHT + ROW_HEIGHT / 2;
+    if (cmpGene) {
+      svgEl.insertAdjacentHTML('beforeend',
+        `<path data-ref-id="${refGene.id}" d="M 0,${y} C 50,${y} 50,${y} 100,${y}"` +
+        ` stroke="${catColor}" stroke-width="${refGene.gene_name ? 9 : 7}"` +
+        ` fill="none" opacity="0.55"/>`);
+    } else {
+      svgEl.insertAdjacentHTML('beforeend',
+        `<circle data-ref-id="${refGene.id}" cx="50" cy="${y}" r="4"` +
+        ` fill="#fca5a5" opacity="0.8"/>`);
+    }
+  }
+
+  _renderedCount = end;
+  const totalH = _renderedCount * ROW_HEIGHT;
+  svgEl.setAttribute('height', totalH);
+  svgEl.setAttribute('viewBox', `0 0 100 ${totalH}`);
+}
+
+function buildRow(gene, catColor, isRef, refId = null) {
+  const named = !!(gene.gene_name || gene.gene_symbol);
+  const displayName = gene.gene_name || gene.gene_symbol || '';
+  const locusTag = gene.locus_tag ?? '';
+  const r = parseInt(catColor.slice(1,3), 16);
+  const g = parseInt(catColor.slice(3,5), 16);
+  const b = parseInt(catColor.slice(5,7), 16);
+  const bgTint = `rgba(${r},${g},${b},0.06)`;
+
+  const row = document.createElement('div');
+  row.className = 'ga-row';
+  row.dataset.refId = isRef ? gene.id : (refId ?? gene.id);
+  row.dataset.geneId = gene.id;
+  row.style.cssText = [
+    `height:${ROW_HEIGHT}px`,
+    'overflow:hidden',
+    'cursor:pointer',
+    `border-left:4px solid ${catColor}`,
+    `background:${bgTint}`,
+    'display:flex',
+    'align-items:center',
+    'padding:0 6px 0 6px',
+    'gap:5px',
+    'box-sizing:border-box',
+    'position:relative',
+    'border-bottom:1px solid rgba(0,0,0,0.03)',
+  ].join(';');
+
+  const tagSpan = document.createElement('span');
+  tagSpan.style.cssText = 'font-family:monospace;font-size:10px;flex-shrink:0;color:' +
+    (named ? '#1a1a1a' : '#9ca3af');
+  tagSpan.textContent = locusTag;
+  row.appendChild(tagSpan);
+
+  if (named) {
+    const nameSpan = document.createElement('span');
+    nameSpan.style.cssText = `font-size:10px;font-weight:700;color:${catColor};flex-shrink:0;`;
+    nameSpan.textContent = '· ' + displayName;
+    row.appendChild(nameSpan);
+  }
+
+  row.addEventListener('click', () => toggleExpand(row, gene, catColor, isRef));
+  return row;
+}
+
+function buildGapRow() {
+  const row = document.createElement('div');
+  row.style.cssText = [
+    `height:${ROW_HEIGHT}px`,
+    'display:flex',
+    'align-items:center',
+    'justify-content:center',
+    'font-size:9px',
+    'color:#d1d5db',
+    'font-style:italic',
+    'border-bottom:1px solid rgba(0,0,0,0.03)',
+  ].join(';');
+  row.textContent = '— no ortholog —';
+  return row;
+}
+
+// ── Expand / collapse (implemented in Task 8) ────────────────
+function toggleExpand(rowEl, gene, catColor, isRef) {
+  // stub — replaced in Task 8
+}

--- a/web/js/views/genome-alignment.js
+++ b/web/js/views/genome-alignment.js
@@ -67,6 +67,7 @@ const ROW_HEIGHT = 22; // px — fixed row height for ribbon Y calculation
 const PAGE_SIZE  = 100;
 
 // ── Module state (reset on each renderGenomeAlignment call) ──
+let _loadGen      = 0;         // incremented on each load to cancel stale fetches
 let _strains      = [];        // [{id, common_name, color_hex, emoji_icon}, ...]
 let _refStrainId  = null;
 let _cmpStrainId  = null;
@@ -160,7 +161,11 @@ export async function renderGenomeAlignment(container) {
 
   _container.querySelector('#ga-retry')?.addEventListener('click', () => {
     showError(false);
-    loadStrains();
+    if (_strains.length === 0) {
+      loadStrains();
+    } else {
+      onPickerChange();
+    }
   });
   _container.querySelector('#ga-search')?.addEventListener('input', onSearch);
 
@@ -217,6 +222,7 @@ async function onPickerChange() {
   }
   showWarning(false);
 
+  _loadGen++;
   _refStrainId  = refId;
   _cmpStrainId  = cmpId;
   _renderedCount = 0;
@@ -241,6 +247,7 @@ async function onPickerChange() {
 }
 
 async function loadGenes() {
+  const gen = _loadGen;
   const GENE_COLS = 'id,locus_tag,gene_name,gene_symbol,product,functional_category,sort_index,is_characterized';
 
   const [refRes, cmpRes] = await Promise.all([
@@ -262,6 +269,8 @@ async function loadGenes() {
     return;
   }
 
+  if (gen !== _loadGen) return;
+
   _refGenes = refRes.data ?? [];
   _cmpGenes = cmpRes.data ?? [];
 
@@ -279,6 +288,14 @@ async function loadGenes() {
       .eq('strain_id_a', _cmpStrainId)
       .eq('strain_id_b', _refStrainId),
   ]);
+
+  if (o1.error || o2.error) {
+    showError(true);
+    _container.querySelector('#ga-empty').textContent = 'Select two genomes above to begin.';
+    return;
+  }
+
+  if (gen !== _loadGen) return;
 
   _orthologMap = new Map();
   const cmpIdSet = new Set(_cmpGenes.map(g => g.id));
@@ -307,6 +324,7 @@ async function loadGenes() {
 
 // ── Navigation ───────────────────────────────────────────────
 function buildJumpChips() {
+  if (!_refGenes.length) return;
   const chipsEl = _container.querySelector('#ga-jump-chips');
   const jumpRow = _container.querySelector('#ga-jump-row');
   chipsEl.innerHTML = '';


### PR DESCRIPTION
## Summary

- **Genome alignment tool**: full new tool under Tools menu — side-by-side comparison of any two Chlamydia strain genomes with ortholog mapping, SVG connector column, paginated gene list, jump chips, and gene search
- **Redesigned layout**: 3-column page (jump chips sidebar | constrained 680px gene columns | legend/key sidebar) replacing original full-width design; genome pickers centered above columns with strain icon + dynamic color
- **Connector column**: thin 1.5px category-colored SVG lines (replacing thick bezier ribbons); pink dot for genes with no ortholog; highlights on expand
- **Expand on click**: gene detail card on both reference and comparison columns; lazy-loaded protein size (aa / kDa); → Gene detail navigation

## Test Plan
- [ ] Select two genomes (e.g. CT-L2 and CT-D) — pickers show strain icon with colored border, no text overlap
- [ ] Gene list loads with Reference / Comparison column labels visible below pickers
- [ ] Scroll through gene list — labels stay fixed, sidebars stay visible
- [ ] Jump chips navigate to correct gene index
- [ ] Search by locus tag or gene name scrolls to correct row
- [ ] Click a gene row — expand card shows product, category badge, protein size, → Gene detail on both sides
- [ ] Click again — collapses, connector line restores
- [ ] Right sidebar Key shows all categories + ortholog/no-ortholog connector legend

🤖 Generated with [Claude Code](https://claude.com/claude-code)