### PR TITLE
dev → main: Bug Reports, CT-L2 genes, UI polish, nav fixes

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -113,7 +113,6 @@ export function openAlignmentWith(geneId) {
   state.alignmentSeedGeneId = geneId;
   activateTab('alignment');
 }
-window._openAlignmentWith = openAlignmentWith;
 
 // ─── Auth ─────────────────────────────────────────────────
 // Fetch the user's profile row using the access_token we already have from the

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1,12 +1,12 @@
 // ChlamAtlas — main application entry point
 import { sb, state, SUPABASE_URL, SUPABASE_ANON_KEY, syncFavoritesFromDB } from './client.js?v=81';
 import { renderHome } from './views/home.js?v=81';
-import { renderGenomes } from './views/genomes.js?v=87';
+import { renderGenomes } from './views/genomes.js?v=88';
 import { renderMutants } from './views/mutants.js?v=92';
 import { renderPipeline } from './views/pipeline.js?v=65';
 import { renderRoadmap }  from './views/roadmap.js?v=91';
 import { renderAlignment } from './views/alignment.js?v=96';
-import { renderStructureAlignment } from './views/structure-alignment.js?v=6';
+import { renderStructureAlignment } from './views/structure-alignment.js?v=7';
 import { renderGenomeAlignment } from './views/genome-alignment.js?v=1';
 import { renderBugs } from './views/bugs.js?v=1';
 
@@ -113,6 +113,7 @@ export function openAlignmentWith(geneId) {
   state.alignmentSeedGeneId = geneId;
   activateTab('alignment');
 }
+window._openAlignmentWith = openAlignmentWith;
 
 // ─── Auth ─────────────────────────────────────────────────
 // Fetch the user's profile row using the access_token we already have from the
@@ -1202,7 +1203,7 @@ document.getElementById('nav-home-logo').addEventListener('click', (e) => {
   activateTab('home');
 });
 
-document.addEventListener('chlamatlas:navigate', (e) => {
+window.addEventListener('chlamatlas:navigate', (e) => {
   const { tab } = e.detail ?? {};
   if (tab) activateTab(tab);
 });

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1,11 +1,11 @@
 // ChlamAtlas — main application entry point
 import { sb, state, SUPABASE_URL, SUPABASE_ANON_KEY, syncFavoritesFromDB } from './client.js?v=81';
 import { renderHome } from './views/home.js?v=81';
-import { renderGenomes } from './views/genomes.js?v=88';
+import { renderGenomes } from './views/genomes.js?v=89';
 import { renderMutants } from './views/mutants.js?v=92';
 import { renderPipeline } from './views/pipeline.js?v=65';
 import { renderRoadmap }  from './views/roadmap.js?v=91';
-import { renderAlignment } from './views/alignment.js?v=96';
+import { renderAlignment } from './views/alignment.js?v=97';
 import { renderStructureAlignment } from './views/structure-alignment.js?v=7';
 import { renderGenomeAlignment } from './views/genome-alignment.js?v=1';
 import { renderBugs } from './views/bugs.js?v=1';

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1202,7 +1202,7 @@ document.getElementById('nav-home-logo').addEventListener('click', (e) => {
   activateTab('home');
 });
 
-window.addEventListener('chlamatlas:navigate', (e) => {
+document.addEventListener('chlamatlas:navigate', (e) => {
   const { tab } = e.detail ?? {};
   if (tab) activateTab(tab);
 });

--- a/web/js/views/alignment.js
+++ b/web/js/views/alignment.js
@@ -31,17 +31,22 @@ async function loadStrains() {
 export function renderAlignment(container) {
   _container = container;
   alignState = { seqType: 'dna', entries: [], results: null, running: false };
-  loadStrains().then(() => render()).catch(() => render());
-  if (state.alignmentSeedGeneId) {
-    const seedId = state.alignmentSeedGeneId;
-    state.alignmentSeedGeneId = null;
-    sb.from('genes')
-      .select('id,locus_tag,gene_name,gene_symbol,strain_id')
-      .eq('id', seedId)
-      .single()
-      .then(({ data }) => { if (data) addGeneWithOrthologs(data); })
-      .catch(err => console.error('Failed to fetch seed gene:', err));
-  }
+
+  const seedId = state.alignmentSeedGeneId ?? null;
+  state.alignmentSeedGeneId = null;
+
+  const seedPromise = seedId
+    ? sb.from('genes').select('id,locus_tag,gene_name,gene_symbol,strain_id').eq('id', seedId).single()
+        .then(({ data }) => data || null)
+        .catch(() => null)
+    : Promise.resolve(null);
+
+  Promise.all([loadStrains(), seedPromise])
+    .then(([, seedGene]) => {
+      if (seedGene) addGeneWithOrthologs(seedGene);
+      render();
+    })
+    .catch(() => render());
 }
 
 function render() {

--- a/web/js/views/genomes.js
+++ b/web/js/views/genomes.js
@@ -916,12 +916,7 @@ function renderDetailGeneInfo(detail, gene) {
   const el = detail.querySelector('#d-gene-info');
   if (!el) return;
   el.innerHTML = `
-    ${sectionHead('Gene Info', `
-      <div style="display:flex;gap:6px;align-items:center;">
-        ${seqCopyBtn('Copy DNA', gene.dna_sequence)}
-        ${alignOrthologsBtn(gene.id)}
-      </div>
-    `)}
+    ${sectionHead('Gene Info', seqCopyBtn('Copy DNA', gene.dna_sequence))}
     <div style="padding:2px 16px 14px;">
       <div style="display:flex;gap:32px;flex-wrap:wrap;margin-bottom:8px;">
         ${prop('Length', lengthLabel)}
@@ -1119,11 +1114,6 @@ function renderDetailMutants(detail, gene, mutants) {
   });
 }
 
-// ── Cross-view navigation: seed structure alignment from gene detail ──────────
-window._seedStructureAlignment = (geneId) => {
-  state.structureAlignmentSeedGeneId = geneId;
-  window.dispatchEvent(new CustomEvent('chlamatlas:navigate', { detail: { tab: 'structure-alignment' } }));
-};
 
 function renderDetailOrthologs(detail, orthoRows, gene) {
   const el = detail.querySelector('#d-orthologs');
@@ -1397,16 +1387,6 @@ function renderDetailProtein(detail, gene, protein) {
 
 // Generates an "Align Orthologs" shortcut button that opens the alignment tool
 // pre-seeded with the given gene (and its orthologs) via openAlignmentWith.
-const _toolBtnStyle = `display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:600;color:#0f4530;background:#f0fdf4;border:1.5px solid #86efac;border-radius:7px;padding:5px 11px;cursor:pointer;font-family:'DM Sans',sans-serif;`;
-const _seqIcon  = `<svg width="13" height="13" viewBox="0 0 15 15" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" style="display:block;flex-shrink:0;opacity:0.7"><line x1="1" y1="4" x2="11" y2="4"/><line x1="4" y1="7.5" x2="14" y2="7.5"/><line x1="2" y1="11" x2="12" y2="11"/></svg>`;
-const _structIcon = `<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="display:block;flex-shrink:0;opacity:0.7"><path d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9"/></svg>`;
-
-function alignOrthologsBtn(geneId) {
-  return `<button onclick="window._openAlignmentWith('${geneId}')"
-    style="${_toolBtnStyle}"
-    onmouseenter="this.style.borderColor='#6ee7b7'"
-    onmouseleave="this.style.borderColor='#86efac'">${_seqIcon} Sequence Align</button>`;
-}
 
 // Generates a copy-to-clipboard button for a raw sequence string.
 // Call attachCopyBtns(el) after setting el.innerHTML to wire up the listener.
@@ -1924,12 +1904,6 @@ function renderDetailStructure(detail, gene, protein, afRows) {
           ${inferredHtml}
           <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
             ${linksHtml}
-            <button onclick="window._seedStructureAlignment('${esc(gene.id)}')"
-              style="${_toolBtnStyle}"
-              onmouseenter="this.style.borderColor='#6ee7b7'"
-              onmouseleave="this.style.borderColor='#86efac'">
-              ${_structIcon} Structure Align
-            </button>
           </div>
         </div>
       </div>`;

--- a/web/js/views/genomes.js
+++ b/web/js/views/genomes.js
@@ -1122,7 +1122,7 @@ function renderDetailMutants(detail, gene, mutants) {
 // ── Cross-view navigation: seed structure alignment from gene detail ──────────
 window._seedStructureAlignment = (geneId) => {
   state.structureAlignmentSeedGeneId = geneId;
-  document.dispatchEvent(new CustomEvent('chlamatlas:navigate', { detail: { tab: 'structure-alignment' } }));
+  window.dispatchEvent(new CustomEvent('chlamatlas:navigate', { detail: { tab: 'structure-alignment' } }));
 };
 
 function renderDetailOrthologs(detail, orthoRows, gene) {
@@ -1398,7 +1398,7 @@ function renderDetailProtein(detail, gene, protein) {
 // Generates an "Align Orthologs" shortcut button that opens the alignment tool
 // pre-seeded with the given gene (and its orthologs) via openAlignmentWith.
 function alignOrthologsBtn(geneId) {
-  return `<button onclick="(async()=>{const {openAlignmentWith}=await import('./app.js?v=82');openAlignmentWith('${geneId}');})()"
+  return `<button onclick="window._openAlignmentWith('${geneId}')"
     style="display:inline-flex;align-items:center;gap:4px;font-size:8px;font-weight:600;
            color:#0f4530;background:#f0fdf4;border:1px solid #86efac;border-radius:5px;
            padding:2px 8px;cursor:pointer;line-height:1.4;font-family:inherit;"

--- a/web/js/views/genomes.js
+++ b/web/js/views/genomes.js
@@ -1397,13 +1397,15 @@ function renderDetailProtein(detail, gene, protein) {
 
 // Generates an "Align Orthologs" shortcut button that opens the alignment tool
 // pre-seeded with the given gene (and its orthologs) via openAlignmentWith.
+const _toolBtnStyle = `display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:600;color:#0f4530;background:#f0fdf4;border:1.5px solid #86efac;border-radius:7px;padding:5px 11px;cursor:pointer;font-family:'DM Sans',sans-serif;`;
+const _seqIcon  = `<svg width="13" height="13" viewBox="0 0 15 15" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" style="display:block;flex-shrink:0;opacity:0.7"><line x1="1" y1="4" x2="11" y2="4"/><line x1="4" y1="7.5" x2="14" y2="7.5"/><line x1="2" y1="11" x2="12" y2="11"/></svg>`;
+const _structIcon = `<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="display:block;flex-shrink:0;opacity:0.7"><path d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9"/></svg>`;
+
 function alignOrthologsBtn(geneId) {
   return `<button onclick="window._openAlignmentWith('${geneId}')"
-    style="display:inline-flex;align-items:center;gap:4px;font-size:8px;font-weight:600;
-           color:#0f4530;background:#f0fdf4;border:1px solid #86efac;border-radius:5px;
-           padding:2px 8px;cursor:pointer;line-height:1.4;font-family:inherit;"
+    style="${_toolBtnStyle}"
     onmouseenter="this.style.borderColor='#6ee7b7'"
-    onmouseleave="this.style.borderColor='#86efac'">⇔ Align</button>`;
+    onmouseleave="this.style.borderColor='#86efac'">${_seqIcon} Sequence Align</button>`;
 }
 
 // Generates a copy-to-clipboard button for a raw sequence string.
@@ -1923,10 +1925,10 @@ function renderDetailStructure(detail, gene, protein, afRows) {
           <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
             ${linksHtml}
             <button onclick="window._seedStructureAlignment('${esc(gene.id)}')"
-              style="display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:600;
-                     color:#0f4530;background:#f0fdf4;border:1.5px solid #86efac;border-radius:7px;
-                     padding:5px 11px;cursor:pointer;font-family:'DM Sans',sans-serif;">
-              🔬 Compare structures
+              style="${_toolBtnStyle}"
+              onmouseenter="this.style.borderColor='#6ee7b7'"
+              onmouseleave="this.style.borderColor='#86efac'">
+              ${_structIcon} Structure Align
             </button>
           </div>
         </div>

--- a/web/js/views/structure-alignment.js
+++ b/web/js/views/structure-alignment.js
@@ -120,18 +120,22 @@ function hexToMolColor(hex) {
 export function renderStructureAlignment(container) {
   _container = container;
   strState = { entries: [], loaded: false, bgDark: true, hintDismissed: false, viewer: null };
-  loadStrains().then(() => render()).catch(() => render());
 
-  if (state.structureAlignmentSeedGeneId) {
-    const seedId = state.structureAlignmentSeedGeneId;
-    state.structureAlignmentSeedGeneId = null;
-    sb.from('genes')
-      .select('id,locus_tag,gene_name,gene_symbol,strain_id')
-      .eq('id', seedId)
-      .single()
-      .then(({ data }) => { if (data) addPrimaryGene(data); })
-      .catch(err => console.error('[StructureAlignment] seed fetch failed:', err));
-  }
+  const seedId = state.structureAlignmentSeedGeneId ?? null;
+  state.structureAlignmentSeedGeneId = null;
+
+  const seedPromise = seedId
+    ? sb.from('genes').select('id,locus_tag,gene_name,gene_symbol,strain_id').eq('id', seedId).single()
+        .then(({ data }) => data || null)
+        .catch(() => null)
+    : Promise.resolve(null);
+
+  Promise.all([loadStrains(), seedPromise])
+    .then(([, seedGene]) => {
+      if (seedGene) addPrimaryGene(seedGene);
+      render();
+    })
+    .catch(() => render());
 }
 
 // ── Top-level render ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Bug Reports page** (`#bugs`): Supabase-backed intake (migration 028). Public read, authenticated submit, admin resolve. User dropdown entry with SVG icon.
- **CT-L2 gene data complete**: CTL0414, CTL0420, CTL0856 with protein data, orthologs, mmCIF, and structure thumbnails. pL2 boundary corrected (873–880).
- **User dropdown polish**: SVG icons on all rows, max-width 220px, opening the dropdown now closes any open nav popover.
- **What's New changelog**: Updated through v0.9.9 — chimera detail, genome alignment redesign, CT-L2 genes, bug reports, production deployment.
- **Nav fixes**: Standardized all `chlamatlas:navigate` dispatches to `window` (was mixed `document`/`window`), fixing home page cards and cross-tab navigation.
- **Sequence alignment pre-population**: Applied `Promise.all` race-condition fix to `alignment.js` (seed gene now guaranteed in state before `render()` fires).

## Test plan

- [ ] Run migration 028 in Supabase dashboard if not already applied (`bug_reports` table + RLS)
- [ ] Bug Reports page loads from user dropdown; submit a report; admin Resolve button removes it
- [ ] CTL0856 gene detail shows correct structure thumbnail (verify in incognito if cached)
- [ ] Home page strain/mutant cards navigate correctly
- [ ] User dropdown is compact with icons; closes any open nav popover when triggered
- [ ] What's New changelog shows entries through v0.9.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)