### PR TITLE
feat: gene list strain switcher + accumulated dev work

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1,7 +1,7 @@
 // ChlamAtlas — main application entry point
 import { sb, state, SUPABASE_URL, SUPABASE_ANON_KEY, syncFavoritesFromDB } from './client.js?v=81';
 import { renderHome } from './views/home.js?v=81';
-import { renderGenomes } from './views/genomes.js?v=89';
+import { renderGenomes } from './views/genomes.js?v=90';
 import { renderMutants } from './views/mutants.js?v=92';
 import { renderPipeline } from './views/pipeline.js?v=65';
 import { renderRoadmap }  from './views/roadmap.js?v=91';

--- a/web/js/views/genomes.js
+++ b/web/js/views/genomes.js
@@ -193,13 +193,14 @@ function showGeneList(container) {
       <!-- ── List panel ── -->
       <div id="list-panel" style="border-right:1px solid #ececec;display:flex;flex-direction:column;overflow:hidden;">
 
-        <!-- Strain tabs -->
-        <div id="strain-tabs" style="display:flex;border-bottom:1px solid #efefef;padding:10px 14px 0;flex-shrink:0;">
-          ${STRAINS.map(s => `
-            <button data-strain="${s.id}" aria-label="View ${s.label} genes"
-              style="font-size:11.5px;font-weight:600;padding:5px 11px 8px;border:none;border-bottom:2px solid transparent;background:none;cursor:pointer;margin-bottom:-1px;white-space:nowrap;color:${s.id === _strain ? '#16a34a' : '#9ca3af'};border-bottom-color:${s.id === _strain ? '#16a34a' : 'transparent'};">
-              ${s.label}
-            </button>`).join('')}
+        <!-- Strain strip -->
+        <div class="mut-strip" id="strain-strip">
+          <img class="mut-strip-icon" id="strain-strip-icon" src="${STRAINS.find(s => s.id === _strain)?.icon ?? ''}" alt="">
+          <div style="flex:1;min-width:0;">
+            <div class="mut-strip-name" id="strain-strip-name">${STRAINS.find(s => s.id === _strain)?.label ?? _strain}</div>
+            <div class="mut-strip-count" id="strain-strip-count">Loading…</div>
+          </div>
+          <button class="mut-switch-btn" id="strain-switch-btn">Switch ▾</button>
         </div>
 
         <!-- Search -->
@@ -214,9 +215,6 @@ function showGeneList(container) {
 
         <!-- Filter/sort toolbar -->
         <div id="filter-bar" style="flex-shrink:0;"></div>
-
-        <!-- Result count -->
-        <div id="result-count" style="font-size:9px;color:#bbb;font-family:'DM Mono',monospace;padding:3px 12px 3px;border-bottom:1px solid #f5f5f5;flex-shrink:0;"></div>
 
         <!-- Gene list (scrollable) -->
         <div id="gene-scroll" style="overflow-y:auto;flex:1;">
@@ -240,25 +238,9 @@ function showGeneList(container) {
   const geneScrollEl = container.querySelector('#gene-scroll');
   if (geneScrollEl) geneScrollEl.scrollTop = 0;
 
-  // Wire strain tabs
-  container.querySelectorAll('[data-strain]').forEach(btn => {
-    btn.addEventListener('click', () => {
-      _strain = btn.dataset.strain;
-      _search = ''; _offset = 0; _selectedId = null; _categoryFilter = null; _locationFilter = null;
-      _expressionFilter = null;
-      _filters = { favorites: false, characterized: false, hypothetical: false, inc: false,
-                   membrane: false, secreted: false, dnaBinding: false,
-                   hasAf3: false, hasCrystal: false };
-      // Update tab styles
-      container.querySelectorAll('[data-strain]').forEach(b => {
-        const active = b.dataset.strain === _strain;
-        b.style.color = active ? '#16a34a' : '#9ca3af';
-        b.style.borderBottomColor = active ? '#16a34a' : 'transparent';
-      });
-      container.querySelector('#gene-search').value = '';
-      renderFilterBar(container);
-      fetchGenes(container, true);
-    });
+  // Wire strain switcher
+  container.querySelector('#strain-switch-btn').addEventListener('click', e => {
+    showStrainDropdown(e.currentTarget, container);
   });
 
   // Wire search
@@ -301,7 +283,7 @@ function showGeneList(container) {
     if (_filters.favorites && !nowFav) {
       favBtn.closest('.gene-row')?.remove();
       _total = Math.max(0, _total - 1);
-      const countEl = container.querySelector('#result-count');
+      const countEl = container.querySelector('#strain-strip-count');
       if (countEl) countEl.textContent = `${_total.toLocaleString()} gene${_total !== 1 ? 's' : ''}`;
     }
     // Also update the star in the detail panel if this gene is selected
@@ -310,6 +292,40 @@ function showGeneList(container) {
       detailFav.textContent = nowFav ? '★' : '☆';
       detailFav.style.color  = nowFav ? '#f59e0b' : '#e5e7eb';
     }
+  });
+}
+
+function showStrainDropdown(anchor, container) {
+  const openPop = window.__openNavPopover;
+  if (!openPop) return;
+
+  openPop(anchor, `
+    <div class="nav-popover-label">Strains</div>
+    ${STRAINS.map(s => `
+      <button class="nav-popover-row" data-strain="${s.id}">
+        <img style="width:24px;height:24px;object-fit:contain;" src="${s.icon}" alt="">
+        <span class="nav-popover-row-name">${s.label}</span>
+      </button>`).join('')}
+  `, 'gene-strain-popover');
+
+  const pop = document.getElementById('gene-strain-popover');
+  pop?.querySelectorAll('[data-strain]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      _strain = btn.dataset.strain;
+      const s = STRAINS.find(x => x.id === _strain);
+      container.querySelector('#strain-strip-icon').src = s?.icon ?? '';
+      container.querySelector('#strain-strip-name').textContent = s?.label ?? _strain;
+      container.querySelector('#strain-strip-count').textContent = 'Loading…';
+      _search = ''; _offset = 0; _selectedId = null; _categoryFilter = null; _locationFilter = null;
+      _expressionFilter = null;
+      _filters = { favorites: false, characterized: false, hypothetical: false, inc: false,
+                   membrane: false, secreted: false, dnaBinding: false,
+                   hasAf3: false, hasCrystal: false };
+      container.querySelector('#gene-search').value = '';
+      pop.remove();
+      renderFilterBar(container);
+      fetchGenes(container, true);
+    });
   });
 }
 
@@ -661,7 +677,7 @@ async function fetchGenes(container, reset = false) {
   _hasMore = (_offset + PAGE_SIZE) < _total;
 
   // Update result count
-  const countEl = container.querySelector('#result-count');
+  const countEl = container.querySelector('#strain-strip-count');
   if (countEl) countEl.textContent = `${_total.toLocaleString()} gene${_total !== 1 ? 's' : ''}`;
 
   if (!genes?.length) {


### PR DESCRIPTION
## Summary

- **Gene list strain switcher** — replaces underline tabs with the same strip + popover pattern used by the mutant collection picker (icon, label, live count, "Switch ▾" button). Consistent UI across both list views.
- Genome Alignment tool (3-column layout: jump chips | gene columns | legend)
- Chimera mutant detail — recombination span schema, genome map SVG, gene exchange panel
- Bug Reports page (`#bugs` tab, Supabase-backed, public read / auth submit / admin resolve)
- CT-L2 missing genes added (CTL0414, CTL0420, CTL0856) with protein data, orthologs, mmCIF, thumbnails
- User dropdown SVG icons + closes nav popovers on open
- What's New changelog updated through v0.9.9
- Nav event bus standardized to `window` (home page strain/mutant cards now navigate correctly)
- Sequence alignment pre-pop race condition fixed

## Test plan

- [ ] Genomes tab: strain strip shows icon + label + count; "Switch ▾" opens popover with all 3 strains; switching reloads list and resets filters
- [ ] Mutants tab: collection strip unchanged and still works
- [ ] Genome Alignment tool: strain pickers, connector lines, expand cards
- [ ] Chimera mutant detail: genome map + gene exchange panel on a Chimera record (e.g. RC1203)
- [ ] Bug Reports tab: visible, submit works when signed in
- [ ] CT-L2 gene list includes CTL0414, CTL0420, CTL0856

🤖 Generated with [Claude Code](https://claude.com/claude-code)