### PR TITLE
Mutant list polish — type pills, chimera locus, marker filter, duplicate cleanup

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -370,6 +370,6 @@
   <!-- Supabase JS client (ESM via CDN) -->
   <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.min.js"></script>
   <script src="/web/js/chlam-globe-bg.js"></script>
-  <script type="module" src="/web/js/app.js?v=83"></script>
+  <script type="module" src="/web/js/app.js?v=84"></script>
 </body>
 </html>

--- a/web/js/views/mutants.js
+++ b/web/js/views/mutants.js
@@ -575,7 +575,7 @@ function renderFilterBar() {
           .select('marker')
           .eq('collection', _collection)
           .not('marker', 'is', null);
-        _markerOptions = [...new Set((data ?? []).map(r => r.marker))].sort();
+        _markerOptions = [...new Set((data ?? []).flatMap(r => r.marker ?? []))].sort();
       }
 
       markerList.innerHTML = _markerOptions.length
@@ -668,7 +668,7 @@ async function fetchList() {
     displayRows = displayRows.filter(m => m.creator_name === _filters.creator);
   }
   if (_filters.marker) {
-    displayRows = displayRows.filter(m => m.marker === _filters.marker);
+    displayRows = displayRows.filter(m => m.marker?.includes(_filters.marker));
   }
 
   // Update count display (after filters)

--- a/web/js/views/mutants.js
+++ b/web/js/views/mutants.js
@@ -405,19 +405,18 @@ function renderFilterBar() {
         </div>
       </div>
       ${groupHead('marker', '🏷', 'Marker', secOpen.marker)}
-      <div style="display:${secOpen.marker ? 'block' : 'none'};padding-bottom:4px;">
-        <div style="position:relative;display:inline-block;">
-          <button id="mut-marker-btn"
-            style="font-size:10.5px;font-weight:600;padding:3px 9px;border-radius:6px;white-space:nowrap;cursor:pointer;font-family:inherit;
-                   border:1px solid ${_filters.marker ? '#99f6e4' : '#e5e7eb'};
-                   background:${_filters.marker ? '#f0fdfa' : 'white'};
-                   color:${_filters.marker ? '#0f766e' : '#9ca3af'};">
-            ${_filters.marker ? `🏷 ${esc(_filters.marker)}` : 'Select marker ▾'}
-          </button>
-          <div id="mut-marker-drop" style="display:none;position:absolute;top:100%;left:0;margin-top:2px;background:white;border:1px solid #e5e7eb;border-radius:8px;box-shadow:0 4px 12px rgba(0,0,0,0.08);z-index:50;min-width:140px;overflow:hidden;">
-            <div id="mut-marker-list" style="padding:4px 0;"><div style="padding:8px 14px;font-size:11px;color:#9ca3af;">Loading…</div></div>
-          </div>
-        </div>
+      <div style="display:${secOpen.marker ? 'flex' : 'none'};flex-wrap:wrap;gap:5px;padding-bottom:4px;" id="mut-marker-chips">
+        ${_markerOptions.length
+          ? _markerOptions.map(mk => {
+              const a = _filters.marker === mk;
+              return `<button data-marker-chip="${esc(mk)}"
+                style="font-size:10.5px;font-weight:600;padding:3px 9px;border-radius:20px;white-space:nowrap;cursor:pointer;font-family:'DM Mono',ui-monospace,monospace;
+                       border:1px solid ${a ? '#99f6e4' : '#e5e7eb'};background:${a ? '#f0fdfa' : 'white'};color:${a ? '#0f766e' : '#9ca3af'};">
+                ${esc(mk)}${a ? ' ×' : ''}
+              </button>`;
+            }).join('')
+          : secOpen.marker ? `<span style="font-size:11px;color:#9ca3af;padding:2px 0;">Loading…</span>` : ''
+        }
       </div>
     </div>
   `;
@@ -461,11 +460,19 @@ function renderFilterBar() {
     renderFilterBar();
   });
 
-  // Section expand/collapse
+  // Section expand/collapse — lazy-loads marker options on first open
   bar.querySelectorAll('[data-section]').forEach(btn => {
-    btn.addEventListener('click', () => {
+    btn.addEventListener('click', async () => {
       const id = btn.dataset.section;
       if (id in _expandedSections) _expandedSections[id] = !_expandedSections[id];
+      if (id === 'marker' && _expandedSections.marker && !_markerOptions.length) {
+        const { data } = await sb
+          .from('mutants')
+          .select('marker')
+          .eq('collection', _collection)
+          .not('marker', 'is', null);
+        _markerOptions = [...new Set((data ?? []).flatMap(r => r.marker ?? []))].sort();
+      }
       renderFilterBar();
     });
   });
@@ -558,52 +565,15 @@ function renderFilterBar() {
     });
   }
 
-  // Marker dropdown
-  const markerBtn  = bar.querySelector('#mut-marker-btn');
-  const markerDrop = bar.querySelector('#mut-marker-drop');
-  const markerList = bar.querySelector('#mut-marker-list');
-  if (markerBtn && markerDrop && markerList) {
-    markerBtn.addEventListener('click', async e => {
-      e.stopPropagation();
-      const open = markerDrop.style.display === 'none';
-      markerDrop.style.display = open ? 'block' : 'none';
-      if (!open) return;
-
-      if (!_markerOptions.length) {
-        const { data } = await sb
-          .from('mutants')
-          .select('marker')
-          .eq('collection', _collection)
-          .not('marker', 'is', null);
-        _markerOptions = [...new Set((data ?? []).flatMap(r => r.marker ?? []))].sort();
-      }
-
-      markerList.innerHTML = _markerOptions.length
-        ? [
-            ...(_filters.marker ? [`<button data-marker-pick="" style="display:block;width:100%;text-align:left;padding:8px 14px;font-size:11.5px;border:none;cursor:pointer;font-family:inherit;color:#9ca3af;background:none;">Clear filter</button>`] : []),
-            ..._markerOptions.map(m => `
-              <button data-marker-pick="${esc(m)}"
-                style="display:block;width:100%;text-align:left;padding:8px 14px;font-size:11.5px;font-family:'DM Mono',ui-monospace,monospace;border:none;cursor:pointer;
-                       font-weight:${_filters.marker === m ? '600' : '400'};
-                       color:${_filters.marker === m ? '#0f766e' : '#333'};
-                       background:${_filters.marker === m ? '#f0fdfa' : 'none'};">
-                ${esc(m)}
-              </button>`)
-          ].join('')
-        : `<div style="padding:8px 14px;font-size:11px;color:#9ca3af;">No markers found</div>`;
-
-      markerList.querySelectorAll('[data-marker-pick]').forEach(row => {
-        row.addEventListener('click', () => {
-          _filters.marker = row.dataset.markerPick || null;
-          markerDrop.style.display = 'none';
-          renderFilterBar();
-          fetchList();
-        });
-      });
-
-      setTimeout(() => document.addEventListener('click', () => { markerDrop.style.display = 'none'; }, { once: true }), 0);
+  // Marker chips
+  bar.querySelectorAll('[data-marker-chip]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const val = btn.dataset.markerChip;
+      _filters.marker = _filters.marker === val ? null : val;
+      renderFilterBar();
+      fetchList();
     });
-  }
+  });
 }
 
 // ─── Fetch + render list ──────────────────────────────────
@@ -751,7 +721,7 @@ function mutantRowHTML(m, locusTagStr = '') {
     : '';
 
   const labPill = !m.is_published
-    ? `<span class="mut-lab-pill" style="margin-left:auto;flex-shrink:0;">🔒 Lab</span>`
+    ? `<span class="mut-lab-pill" style="flex-shrink:0;">🔒 Lab</span>`
     : '';
   const isFav = state.favorites.mutants.has(String(m.id));
   const starEl = state.user
@@ -761,23 +731,20 @@ function mutantRowHTML(m, locusTagStr = '') {
     : '';
   // Chimeras: mutant_id (RC1203) is primary, locus span secondary, name tertiary.
   // Other types: long name is primary, mutant_id is the small label above.
+  // Type pill lives at row level (not inside name div) to avoid flex-overflow conflicts.
   const nameBlock = isChimera
-    ? `<div style="display:flex;align-items:center;gap:5px;">
-         <div class="mut-row-name">${m.mutant_id}</div>
-       </div>
+    ? `<div class="mut-row-name">${m.mutant_id}</div>
        ${chimeraLocus}
        ${m.name && m.name !== m.mutant_id ? `<div style="font-size:0.6875rem;color:#9ca3af;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${esc(m.name)}</div>` : ''}`
     : `${m.name ? `<div class="mut-row-id">${m.mutant_id}</div>` : ''}
-       <div style="display:flex;align-items:center;gap:5px;">
-         <div class="mut-row-name" style="flex:1;min-width:0;">${esc(displayName)}</div>
-         ${typePill}
-       </div>
+       <div class="mut-row-name">${esc(displayName)}</div>
        ${locusLabel}`;
   return `
     <div class="mut-row" data-id="${m.id}" role="button" tabindex="0">
       <div style="flex:1;min-width:0;overflow:hidden;">
         ${nameBlock}
       </div>
+      ${typePill}
       ${labPill}
       ${starEl}
     </div>`;

--- a/web/js/views/mutants.js
+++ b/web/js/views/mutants.js
@@ -120,11 +120,12 @@ let _searchTerm       = '';
 let _selectedId       = null;
 let _container        = null;
 let _searchTimer      = null;
-let _filters          = { favorites: false, type: null, strain: null, category: null, published: null, creator: null };
+let _filters          = { favorites: false, type: null, strain: null, category: null, published: null, creator: null, marker: null };
 let _moreOpen         = false;
-let _expandedSections = { type: false, strain: false, function: false, published: false, creator: false };
+let _expandedSections = { type: false, strain: false, function: false, published: false, creator: false, marker: false };
 let _geneDataMap      = new Map();
 let _creatorOptions   = [];  // cached distinct creator_name values for current collection
+let _markerOptions    = [];  // cached distinct marker values for current collection
 
 // ─── Entry point ──────────────────────────────────────────
 
@@ -136,10 +137,11 @@ export function renderMutants(container) {
   _total = 0;
   _searchTerm = '';
   _selectedId = null;
-  _filters = { favorites: false, type: null, strain: null, category: null, published: null, creator: null };
+  _filters = { favorites: false, type: null, strain: null, category: null, published: null, creator: null, marker: null };
   _creatorOptions = [];
+  _markerOptions = [];
   _moreOpen = false;
-  _expandedSections = { type: false, strain: false, function: false, published: false, creator: false };
+  _expandedSections = { type: false, strain: false, function: false, published: false, creator: false, marker: false };
   _geneDataMap = new Map();
 
   // Pre-select a mutant navigated to from another tab (e.g. gene detail Mutants panel)
@@ -281,6 +283,7 @@ function renderFilterBar() {
   const strainObj    = strainOpts.find(s => s.value === _filters.strain);
   const catLabel     = _filters.category ? (FUNC_LABELS[_filters.category] ?? _filters.category) : null;
   const typelabel    = _filters.type ? (TYPE_LABELS[_filters.type] ?? _filters.type) : null;
+  const markerLabel  = _filters.marker ?? null;
 
   const chip = (id, label, active) => `
     <button data-filter="${id}"
@@ -351,6 +354,7 @@ function renderFilterBar() {
       ${catLabel    ? `<button data-clear-category style="font-size:10.5px;font-weight:600;padding:3px 9px;border-radius:20px;border:1px solid #fde68a;background:#fefce8;color:#92400e;cursor:pointer;white-space:nowrap;font-family:inherit;">⚙️ ${catLabel} ×</button>` : ''}
       ${_filters.published !== null ? `<button data-clear-published style="font-size:10.5px;font-weight:600;padding:3px 9px;border-radius:20px;border:1px solid #bbf7d0;background:#f0fdf4;color:#16a34a;cursor:pointer;white-space:nowrap;font-family:inherit;">${_filters.published ? 'Published' : 'Unpublished'} ×</button>` : ''}
       ${_filters.creator ? `<button data-clear-creator style="font-size:10.5px;font-weight:600;padding:3px 9px;border-radius:20px;border:1px solid #e9d5ff;background:#faf5ff;color:#6b21a8;cursor:pointer;white-space:nowrap;font-family:inherit;">👤 ${esc(_filters.creator)} ×</button>` : ''}
+      ${markerLabel  ? `<button data-clear-marker  style="font-size:10.5px;font-weight:600;padding:3px 9px;border-radius:20px;border:1px solid #99f6e4;background:#f0fdfa;color:#0f766e;cursor:pointer;white-space:nowrap;font-family:inherit;">🏷 ${esc(markerLabel)} ×</button>` : ''}
       ${hasMore ? `<button id="mut-more-btn"
         style="font-size:10.5px;font-weight:600;cursor:pointer;margin-left:auto;font-family:inherit;
                color:${_moreOpen ? '#16a34a' : '#9ca3af'};background:white;
@@ -400,6 +404,21 @@ function renderFilterBar() {
           </div>
         </div>
       </div>
+      ${groupHead('marker', '🏷', 'Marker', secOpen.marker)}
+      <div style="display:${secOpen.marker ? 'block' : 'none'};padding-bottom:4px;">
+        <div style="position:relative;display:inline-block;">
+          <button id="mut-marker-btn"
+            style="font-size:10.5px;font-weight:600;padding:3px 9px;border-radius:6px;white-space:nowrap;cursor:pointer;font-family:inherit;
+                   border:1px solid ${_filters.marker ? '#99f6e4' : '#e5e7eb'};
+                   background:${_filters.marker ? '#f0fdfa' : 'white'};
+                   color:${_filters.marker ? '#0f766e' : '#9ca3af'};">
+            ${_filters.marker ? `🏷 ${esc(_filters.marker)}` : 'Select marker ▾'}
+          </button>
+          <div id="mut-marker-drop" style="display:none;position:absolute;top:100%;left:0;margin-top:2px;background:white;border:1px solid #e5e7eb;border-radius:8px;box-shadow:0 4px 12px rgba(0,0,0,0.08);z-index:50;min-width:140px;overflow:hidden;">
+            <div id="mut-marker-list" style="padding:4px 0;"><div style="padding:8px 14px;font-size:11px;color:#9ca3af;">Loading…</div></div>
+          </div>
+        </div>
+      </div>
     </div>
   `;
 
@@ -434,6 +453,7 @@ function renderFilterBar() {
   bar.querySelector('[data-clear-category]')?.addEventListener('click', ()  => { _filters.category = null;  renderFilterBar(); fetchList(); });
   bar.querySelector('[data-clear-published]')?.addEventListener('click', () => { _filters.published = null; renderFilterBar(); fetchList(); });
   bar.querySelector('[data-clear-creator]')?.addEventListener('click', ()   => { _filters.creator = null;   renderFilterBar(); fetchList(); });
+  bar.querySelector('[data-clear-marker]')?.addEventListener('click', ()    => { _filters.marker = null;    renderFilterBar(); fetchList(); });
 
   // More/Less toggle
   bar.querySelector('#mut-more-btn')?.addEventListener('click', () => {
@@ -537,6 +557,53 @@ function renderFilterBar() {
       setTimeout(() => document.addEventListener('click', () => { creatorDrop.style.display = 'none'; }, { once: true }), 0);
     });
   }
+
+  // Marker dropdown
+  const markerBtn  = bar.querySelector('#mut-marker-btn');
+  const markerDrop = bar.querySelector('#mut-marker-drop');
+  const markerList = bar.querySelector('#mut-marker-list');
+  if (markerBtn && markerDrop && markerList) {
+    markerBtn.addEventListener('click', async e => {
+      e.stopPropagation();
+      const open = markerDrop.style.display === 'none';
+      markerDrop.style.display = open ? 'block' : 'none';
+      if (!open) return;
+
+      if (!_markerOptions.length) {
+        const { data } = await sb
+          .from('mutants')
+          .select('marker')
+          .eq('collection', _collection)
+          .not('marker', 'is', null);
+        _markerOptions = [...new Set((data ?? []).map(r => r.marker))].sort();
+      }
+
+      markerList.innerHTML = _markerOptions.length
+        ? [
+            ...(_filters.marker ? [`<button data-marker-pick="" style="display:block;width:100%;text-align:left;padding:8px 14px;font-size:11.5px;border:none;cursor:pointer;font-family:inherit;color:#9ca3af;background:none;">Clear filter</button>`] : []),
+            ..._markerOptions.map(m => `
+              <button data-marker-pick="${esc(m)}"
+                style="display:block;width:100%;text-align:left;padding:8px 14px;font-size:11.5px;font-family:'DM Mono',ui-monospace,monospace;border:none;cursor:pointer;
+                       font-weight:${_filters.marker === m ? '600' : '400'};
+                       color:${_filters.marker === m ? '#0f766e' : '#333'};
+                       background:${_filters.marker === m ? '#f0fdfa' : 'none'};">
+                ${esc(m)}
+              </button>`)
+          ].join('')
+        : `<div style="padding:8px 14px;font-size:11px;color:#9ca3af;">No markers found</div>`;
+
+      markerList.querySelectorAll('[data-marker-pick]').forEach(row => {
+        row.addEventListener('click', () => {
+          _filters.marker = row.dataset.markerPick || null;
+          markerDrop.style.display = 'none';
+          renderFilterBar();
+          fetchList();
+        });
+      });
+
+      setTimeout(() => document.addEventListener('click', () => { markerDrop.style.display = 'none'; }, { once: true }), 0);
+    });
+  }
 }
 
 // ─── Fetch + render list ──────────────────────────────────
@@ -549,7 +616,7 @@ async function fetchList() {
   // Fetch all records for this collection (no server-side sort — we sort client-side)
   let query = sb
     .from('mutants')
-    .select('id,mutant_id,name,mutation_type,is_published,creator_name,target_gene_ids,strains!background_strain_id(common_name)')
+    .select('id,mutant_id,name,mutation_type,is_published,creator_name,target_gene_ids,marker,recombination_start,recombination_end,strains!background_strain_id(common_name)')
     .eq('collection', _collection)
     .limit(1000);
 
@@ -599,6 +666,9 @@ async function fetchList() {
   }
   if (_filters.creator) {
     displayRows = displayRows.filter(m => m.creator_name === _filters.creator);
+  }
+  if (_filters.marker) {
+    displayRows = displayRows.filter(m => m.marker === _filters.marker);
   }
 
   // Update count display (after filters)
@@ -667,6 +737,19 @@ function mutantRowHTML(m, locusTagStr = '') {
   const locusLabel  = locusTagStr
     ? `<div style="font-size:0.625rem;font-family:'DM Mono',ui-monospace,monospace;color:#9ca3af;margin-top:1px;">${locusTagStr}</div>`
     : '';
+
+  // Type pill — shown for CT_L2 and CM where type varies; suppressed for Chimeras/Lucky17
+  const showTypePill = m.mutation_type && _collection !== 'Chimeras' && _collection !== 'Lucky17';
+  const typeAccent   = showTypePill ? (TYPE_ACCENT[m.mutation_type] ?? DEFAULT_ACCENT) : null;
+  const typePill     = showTypePill
+    ? `<span style="display:inline-block;font-size:0.5rem;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;padding:1px 5px;border-radius:4px;background:${typeAccent.badgeBg};color:${typeAccent.badgeText};border:1px solid ${typeAccent.badgeBorder};white-space:nowrap;flex-shrink:0;">${TYPE_LABELS[m.mutation_type] ?? m.mutation_type}</span>`
+    : '';
+
+  // Chimera locus span: recombination_start–recombination_end
+  const chimeraLocus = isChimera && m.recombination_start && m.recombination_end
+    ? `<div style="font-size:0.625rem;font-family:'DM Mono',ui-monospace,monospace;color:#9ca3af;margin-top:1px;">${m.recombination_start}–${m.recombination_end}</div>`
+    : '';
+
   const labPill = !m.is_published
     ? `<span class="mut-lab-pill" style="margin-left:auto;flex-shrink:0;">🔒 Lab</span>`
     : '';
@@ -676,13 +759,19 @@ function mutantRowHTML(m, locusTagStr = '') {
          style="font-size:11px;color:${isFav ? '#f59e0b' : '#e5e7eb'};background:none;border:none;cursor:pointer;flex-shrink:0;padding:0 0 0 4px;"
          title="${isFav ? 'Remove from favorites' : 'Add to favorites'}">${isFav ? '★' : '☆'}</button>`
     : '';
-  // Chimeras: mutant_id (RC1203) is primary, long technical name is muted secondary.
+  // Chimeras: mutant_id (RC1203) is primary, locus span secondary, name tertiary.
   // Other types: long name is primary, mutant_id is the small label above.
   const nameBlock = isChimera
-    ? `<div class="mut-row-name">${m.mutant_id}</div>
+    ? `<div style="display:flex;align-items:center;gap:5px;">
+         <div class="mut-row-name">${m.mutant_id}</div>
+       </div>
+       ${chimeraLocus}
        ${m.name && m.name !== m.mutant_id ? `<div style="font-size:0.6875rem;color:#9ca3af;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${esc(m.name)}</div>` : ''}`
     : `${m.name ? `<div class="mut-row-id">${m.mutant_id}</div>` : ''}
-       <div class="mut-row-name">${esc(displayName)}</div>
+       <div style="display:flex;align-items:center;gap:5px;">
+         <div class="mut-row-name" style="flex:1;min-width:0;">${esc(displayName)}</div>
+         ${typePill}
+       </div>
        ${locusLabel}`;
   return `
     <div class="mut-row" data-id="${m.id}" role="button" tabindex="0">


### PR DESCRIPTION
## Summary

- **Type pills** — colored mutation-type badges inline with each row for CT_L2 and CM collections (green=Transposon, red=Deletion, yellow=Intron, blue=Chemical); suppressed for Chimeras/Lucky17 where all rows are the same type
- **Chimera locus span** — chimera rows now show `recombination_start–recombination_end` (e.g. `CTL0368–CTL0412`) as a sub-label under the RC-#### ID
- **Marker filter** — new section in the More panel with lazy-loaded inline chips (ampR / camR); active chip shown in top bar; array-column-aware filter logic
- **Pill alignment fix** — moved type pill to row level (sibling of lab pill) to prevent flex-overflow conflicts when both pills appear on the same row
- **Duplicate deletion mutants** — 8 empty-record duplicates (L2∆ prefixed, no YW ID, null creator/plasmid/marker) deleted via SQL; YW-keepers untouched

## Test plan

- [ ] CT_L2 list: confirm type pill appears on each row, colored correctly by type
- [ ] CM list: confirm type pills present; Chimeras/Lucky17 collections have no type pills
- [ ] Chimeras list: confirm RC rows show locus span sub-label
- [ ] More → Marker section: open, confirm chips load (ampR / camR), filtering works, active chip appears in top bar and clears correctly
- [ ] Deletion mutants: confirm duplicates (L2∆scc4, L2∆cdu1cdu2, etc.) no longer appear in list; YW keepers (CTΔscc4, CTΔcdu1cdu2, etc.) still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)