### PR TITLE
feat(mobile): gene list + gene detail mobile redesign

### DIFF
--- a/web/css/mobile.css
+++ b/web/css/mobile.css
@@ -54,7 +54,8 @@
   #mob-nav-left,
   #mob-nav-right,
   #mob-detail,
-  #mob-search { display: none !important; }
+  #mob-search,
+  #mob-search-backdrop { display: none !important; }
 }
 
 /* ── Collapsing nav bar styles ── */
@@ -157,30 +158,8 @@
 .mob-tab-btn.active  { color: var(--mob-green); }
 .mob-tab-btn:active  { transform: scale(.93); }
 
-/* PNG tab icons — CSS filter colorizes the black silhouettes */
-.mob-tab-icon {
-  width: 24px;
-  height: 24px;
-  object-fit: contain;
-  display: block;
-  /* Inactive: dark gray-green (#4a5650) */
-  filter: brightness(0) saturate(100%) invert(30%) sepia(10%) saturate(400%) hue-rotate(120deg) brightness(85%);
-  transition: filter .15s;
-}
-.mob-tab-btn.active .mob-tab-icon {
-  /* Active: brand green (#2f9e6e) */
-  filter: brightness(0) saturate(100%) invert(52%) sepia(50%) saturate(500%) hue-rotate(111deg) brightness(90%);
-}
-
-/* Section-header PNG icons (green #277a55) */
-.mob-sec-icon {
-  width: 16px;
-  height: 16px;
-  object-fit: contain;
-  display: block;
-  filter: brightness(0) saturate(100%) invert(40%) sepia(43%) saturate(500%) hue-rotate(112deg) brightness(82%);
-  flex-shrink: 0;
-}
+/* Tab icons (SVG) inherit currentColor from .mob-tab-btn */
+.mob-tab-btn svg { display: block; flex-shrink: 0; }
 
 /* ── Page/screen layout utilities ── */
 @media (max-width: 639px) {
@@ -465,24 +444,40 @@
 }
 #mob-detail-scroll::-webkit-scrollbar { display: none; }
 
-#mob-search {
+/* Search — bottom sheet (slides up from bottom) */
+#mob-search-backdrop {
   position: fixed;
   inset: 0;
+  z-index: 84;
+  background: rgba(15,25,20,.34);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .3s ease;
+}
+#mob-search-backdrop.open { opacity: 1; pointer-events: auto; }
+
+#mob-search {
+  position: fixed;
+  left: 0; right: 0; bottom: 0;
   z-index: 85;
-  background: var(--mob-bg);
-  transform: translateX(100%);
+  background: transparent;
+  transform: translateY(100%);
   transition: transform .34s cubic-bezier(.32,.72,0,1);
   will-change: transform;
-  overflow: hidden;
 }
-#mob-search.open { transform: translateX(0); }
+#mob-search.open { transform: translateY(0); }
+
 #mob-search-scroll {
-  position: absolute;
-  inset: 0;
+  background: var(--mob-paper);
+  border-radius: 26px 26px 0 0;
+  height: 80vh;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
   scrollbar-width: none;
-  padding-top: var(--mob-nav-h);
+  box-shadow: 0 -8px 30px rgba(0,0,0,.2);
+  display: flex;
+  flex-direction: column;
   padding-bottom: calc(var(--mob-tab-h) + 8px);
 }
 #mob-search-scroll::-webkit-scrollbar { display: none; }

--- a/web/css/mobile.css
+++ b/web/css/mobile.css
@@ -813,7 +813,7 @@
   max-width: 120px;
 }
 .mob-ctx-lab .sym { font-weight: 800; color: var(--mob-ink); }
-.mob-ctx-lab.mono { font-family: var(--mob-mono); font-size: 10px; color: var(--mob-ink-3); }
+.mob-ctx-lab.mono { font-size: 10px; color: var(--mob-ink-3); }
 
 .mob-ctx-arrow-slot { display: flex; align-items: center; }
 .mob-ctx-arrow-slot.plus  { align-items: flex-end; }
@@ -838,7 +838,9 @@
 .mob-ctx-arrow.plus  .body { clip-path: polygon(0 0, calc(100% - 11px) 0, 100% 50%, calc(100% - 11px) 100%, 0 100%); }
 .mob-ctx-arrow.minus .body { clip-path: polygon(11px 0, 100% 0, 100% 100%, 11px 100%, 0 50%); }
 .mob-ctx-col.focal .mob-ctx-arrow .body {
-  box-shadow: inset 0 0 0 2px var(--mob-ink), inset 0 -2px 0 rgba(0,0,0,.12);
+  /* drop-shadow applies after clip-path, so it follows the arrow outline perfectly */
+  filter: drop-shadow(0 0 1px var(--mob-ink)) drop-shadow(0 0 1px var(--mob-ink));
+  box-shadow: inset 0 -2px 0 rgba(0,0,0,.12);
 }
 
 .mob-ctx-strand {

--- a/web/css/mobile.css
+++ b/web/css/mobile.css
@@ -884,3 +884,255 @@
   gap: 5px;
 }
 .mob-switch-btn:active { background: #eef1ee; }
+
+/* =========================================================
+   MUTANT DETAIL — targeted-genes scrollable window
+   ========================================================= */
+
+.mob-tg-win {
+  position: relative;
+  margin-top: 13px;
+  border: 1px solid var(--mob-line);
+  border-radius: 14px;
+  background: var(--mob-bg-warm);
+  overflow: hidden;
+}
+.mob-tg-scroll {
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+}
+.mob-tg-scroll::-webkit-scrollbar { width: 5px; }
+.mob-tg-scroll::-webkit-scrollbar-thumb { background: #cfd6d1; border-radius: 9px; }
+
+.mob-tg-row {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 9px 11px;
+  position: relative;
+  cursor: pointer;
+  background: var(--mob-card);
+  transition: background .12s;
+}
+.mob-tg-row:active { background: #f1f5f2; }
+.mob-tg-row + .mob-tg-row { border-top: .5px solid var(--mob-line); }
+.mob-tg-bar  { width: 3px; align-self: stretch; border-radius: 3px; flex: 0 0 3px; }
+.mob-tg-meta { flex: 1; min-width: 0; }
+.mob-tg-name {
+  font-family: var(--mob-sans);
+  font-weight: 800;
+  font-size: 14.5px;
+  color: var(--mob-ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  letter-spacing: -.01em;
+}
+.mob-tg-name .loc {
+  font-family: var(--mob-mono);
+  font-weight: 400;
+  font-size: 11px;
+  color: var(--mob-ink-3);
+  margin-left: 6px;
+}
+.mob-tg-func {
+  font-size: 11.5px;
+  color: var(--mob-ink-3);
+  margin-top: 1px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.mob-role-badge {
+  flex: 0 0 auto;
+  font-family: var(--mob-sans);
+  font-weight: 800;
+  font-size: 10px;
+  letter-spacing: .03em;
+  text-transform: uppercase;
+  padding: 4px 8px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+.mob-tg-fade {
+  position: absolute;
+  left: 1px; right: 1px; bottom: 1px;
+  height: 30px;
+  pointer-events: none;
+  background: linear-gradient(0deg, var(--mob-bg-warm), rgba(247,248,246,0));
+  border-radius: 0 0 14px 14px;
+  transition: opacity .2s ease;
+}
+.mob-tg-count-hint {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 7px;
+  font-family: var(--mob-mono);
+  font-size: 10px;
+  letter-spacing: .06em;
+  color: var(--mob-ink-3);
+  background: var(--mob-bg-warm);
+  border-top: .5px solid var(--mob-line);
+}
+
+.mob-mut-tile {
+  width: 38px;
+  height: 38px;
+  border-radius: 9px;
+  display: grid;
+  place-items: center;
+  font-family: var(--mob-mono);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.mob-genotype {
+  font-family: var(--mob-mono);
+  font-size: 13.5px;
+  background: var(--mob-bg-warm);
+  border: 1px solid var(--mob-line);
+  border-radius: 10px;
+  padding: 9px 11px;
+  margin-top: 10px;
+  word-break: break-all;
+  color: var(--mob-ink);
+}
+
+.mob-avail-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 13px;
+  border-radius: 999px;
+  font-family: var(--mob-sans);
+  font-weight: 800;
+  font-size: 13px;
+}
+
+/* =========================================================
+   CHIMERA — recombined region map
+   ========================================================= */
+
+.mob-rr-ruler {
+  position: relative;
+  height: 30px;
+  margin: 18px 3px 0;
+}
+.mob-rr-ruler .base {
+  position: absolute;
+  left: 0; right: 0;
+  top: 24px;
+  height: 1.5px;
+  background: var(--mob-line);
+}
+.mob-rr-lm {
+  position: absolute;
+  top: 0;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.mob-rr-lm .nm {
+  font-family: var(--mob-mono);
+  font-style: italic;
+  font-size: 10px;
+  color: var(--mob-ink-3);
+  white-space: nowrap;
+}
+.mob-rr-lm .tick { width: 1px; height: 7px; background: #cfd6d1; margin-top: 3px; }
+.mob-rr-barwrap { position: relative; margin: 4px 3px 0; }
+.mob-rr-kb {
+  position: absolute;
+  right: 0; top: -15px;
+  font-family: var(--mob-mono);
+  font-size: 10px;
+  color: var(--mob-ink-3);
+}
+.mob-rr-bar {
+  position: relative;
+  height: 26px;
+  border-radius: 6px;
+  background: #2f9e6e;
+  overflow: hidden;
+  box-shadow: inset 0 -2px 0 rgba(0,0,0,.08);
+}
+.mob-rr-block {
+  position: absolute;
+  top: 0; bottom: 0;
+  background: #3f7fc4;
+  box-shadow: inset 0 -2px 0 rgba(0,0,0,.14);
+}
+.mob-rr-span {
+  text-align: center;
+  font-family: var(--mob-mono);
+  font-size: 10.5px;
+  color: var(--mob-ink-2);
+  margin-top: 8px;
+}
+.mob-rr-legend {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-top: 13px;
+  flex-wrap: wrap;
+}
+.mob-rr-leg {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--mob-ink-2);
+  font-weight: 700;
+  white-space: nowrap;
+}
+.mob-rr-leg .sw { width: 12px; height: 12px; border-radius: 3px; }
+
+/* Gene-exchange table */
+.mob-gx-colhead {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 11px;
+  background: var(--mob-bg-warm);
+  border-bottom: .5px solid var(--mob-line);
+  font-family: var(--mob-mono);
+  font-size: 9.5px;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+.mob-gx-colhead .h {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  white-space: nowrap;
+}
+.mob-gx-colhead .h b { font-family: var(--mob-sans); font-weight: 800; font-size: 11px; letter-spacing: 0; }
+.mob-gx-row {
+  display: flex;
+  align-items: stretch;
+  gap: 9px;
+  padding: 9px 11px;
+  background: var(--mob-card);
+}
+.mob-gx-row + .mob-gx-row { border-top: .5px solid var(--mob-line); }
+.mob-gx-bar   { width: 3px; align-self: stretch; border-radius: 3px; flex: 0 0 3px; }
+.mob-gx-main  { flex: 1; min-width: 0; }
+.mob-gx-pair  { display: flex; align-items: center; gap: 8px; }
+.mob-gx-side  { flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.mob-gx-side.r { text-align: right; }
+.mob-gx-loc   { font-family: var(--mob-mono); font-size: 10.5px; color: var(--mob-ink-3); }
+.mob-gx-sym   { font-weight: 800; font-size: 13px; color: var(--mob-ink); margin-left: 5px; }
+.mob-gx-prod  { font-size: 11px; color: var(--mob-ink-3); margin-top: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.mob-gx-none  {
+  font-size: 9.5px; font-weight: 800; letter-spacing: .03em; text-transform: uppercase;
+  color: #c2702b; background: #f6ecdd; padding: 3px 8px; border-radius: 999px;
+}
+.mob-gx-row.noortho { background: #fdf8f0; }
+.mob-gx-row.noortho .mob-gx-bar { background: #d99a3e; }

--- a/web/css/mobile.css
+++ b/web/css/mobile.css
@@ -1,0 +1,549 @@
+/* ChlamAtlas — Mobile design system
+   Fonts: Cormorant Garamond (display/serif) · DM Sans (UI/sans) · DM Mono (accessions/mono)
+   Adapted from Claude Design handoff (design_handoff_genomes, design_handoff_mutants).
+   All mobile-layout rules are inside @media (max-width:639px).
+   Component classes (.mob-card, .mob-grow, etc.) are global — JS renders them into overlays
+   that live outside any media-query boundary.
+*/
+
+/* ── Design tokens ── */
+:root {
+  --mob-pine:       #163b2b;
+  --mob-pine-700:   #1d4a36;
+  --mob-green:      #2f9e6e;
+  --mob-green-ink:  #277a55;
+  --mob-ink:        #18221c;
+  --mob-ink-2:      #4a5650;
+  --mob-ink-3:      #8b958f;
+  --mob-line:       #e9ece9;
+  --mob-line-2:     #f0f2f0;
+  --mob-paper:      #ffffff;
+  --mob-bg:         #f4f6f4;
+  --mob-bg-warm:    #f7f8f6;
+
+  /* Strain colors */
+  --mob-s-l2:  #2f9e6e;
+  --mob-s-d:   #b14a93;
+  --mob-s-cm:  #3f7fc4;
+
+  /* Typography — map to existing loaded fonts */
+  --mob-serif: 'Cormorant Garamond', Georgia, 'Times New Roman', serif;
+  --mob-sans:  'DM Sans', -apple-system, system-ui, sans-serif;
+  --mob-mono:  'DM Mono', ui-monospace, 'Courier New', monospace;
+
+  /* Geometry */
+  --mob-r-lg:   22px;
+  --mob-r-md:   16px;
+  --mob-r-sm:   12px;
+  --mob-nav-h:  52px;
+  --mob-tab-h:  84px;
+
+  /* Shadows */
+  --mob-shadow-card: 0 1px 2px rgba(20,40,30,.05), 0 6px 16px rgba(20,40,30,.04);
+  --mob-shadow-pop:  0 8px 30px rgba(20,40,30,.16);
+}
+
+.mob-root, .mob-root * {
+  -webkit-tap-highlight-color: transparent;
+  box-sizing: border-box;
+}
+
+/* ── Collapsing nav bar styles ── */
+#mob-bar {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--mob-nav-h);
+  z-index: 80;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(247,248,246,.86);
+  backdrop-filter: saturate(180%) blur(18px);
+  -webkit-backdrop-filter: saturate(180%) blur(18px);
+  border-bottom: .5px solid var(--mob-line);
+  opacity: 0;
+  transform: translateY(-4px);
+  pointer-events: none;
+  transition: opacity .18s ease, transform .18s ease;
+}
+#mob-bar.show {
+  opacity: 1;
+  transform: none;
+  pointer-events: auto;
+}
+#mob-bar-title {
+  font-family: var(--mob-serif);
+  font-weight: 600;
+  font-size: 17px;
+  color: var(--mob-ink);
+  max-width: 58%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+#mob-nav-left,
+#mob-nav-right {
+  position: fixed;
+  top: 0;
+  height: var(--mob-nav-h);
+  z-index: 81;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+#mob-nav-left  { left: 8px; }
+#mob-nav-right { right: 10px; }
+
+.mob-gbtn {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  border: none;
+  cursor: pointer;
+  background: rgba(255,255,255,.72);
+  color: var(--mob-ink);
+  box-shadow: 0 1px 3px rgba(0,0,0,.09), inset 0 0 0 .5px rgba(0,0,0,.06);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  transition: transform .12s ease;
+  flex-shrink: 0;
+}
+.mob-gbtn:active { transform: scale(.92); }
+.mob-gbtn.saved-on { color: #e8b400; }
+
+/* ── Bottom tab bar styles ── */
+#mobile-nav {
+  background: rgba(252,253,252,.88) !important;
+  backdrop-filter: saturate(180%) blur(22px) !important;
+  -webkit-backdrop-filter: saturate(180%) blur(22px) !important;
+  border-top: .5px solid var(--mob-line) !important;
+  height: var(--mob-tab-h);
+  padding: 8px 4px env(safe-area-inset-bottom, 14px) !important;
+  align-items: stretch !important;
+}
+
+.mob-tab-btn {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--mob-ink-3);
+  padding: 4px 0;
+  transition: color .15s;
+  font-family: var(--mob-sans);
+}
+.mob-tab-btn .mob-tab-label {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: .01em;
+}
+.mob-tab-btn.active { color: var(--mob-green); }
+.mob-tab-btn:active { transform: scale(.93); }
+
+/* ── Page/screen layout utilities ── */
+@media (max-width: 639px) {
+  main { padding-top: var(--mob-nav-h) !important; }
+
+  .tab-panel {
+    position: fixed !important;
+    top: var(--mob-nav-h);
+    left: 0; right: 0;
+    bottom: var(--mob-tab-h);
+    overflow-y: auto;
+    overflow-x: hidden;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-y: contain;
+    scrollbar-width: none;
+  }
+  .tab-panel::-webkit-scrollbar { display: none; }
+  .tab-panel.hidden { display: none !important; }
+
+  .mob-lt-wrap    { padding: 4px 20px 6px; }
+  .mob-lt-eyebrow {
+    font-family: var(--mob-mono);
+    font-size: 11px;
+    letter-spacing: .14em;
+    text-transform: uppercase;
+    color: var(--mob-green-ink);
+    font-weight: 500;
+    margin: 0 0 4px;
+  }
+  .mob-lt-title {
+    font-family: var(--mob-serif);
+    font-weight: 700;
+    font-size: 38px;
+    line-height: 1.02;
+    color: var(--mob-ink);
+    margin: 0;
+    letter-spacing: -.01em;
+  }
+  .mob-lt-sub {
+    color: var(--mob-ink-2);
+    font-size: 14.5px;
+    margin: 7px 0 0;
+    line-height: 1.45;
+  }
+
+  .mob-pad-bottom { height: calc(var(--mob-tab-h) + 8px); }
+}
+
+/* ── Card, gene-row, chip component styles ── */
+.mob-card {
+  background: var(--mob-paper);
+  border-radius: var(--mob-r-lg);
+  margin: 12px 16px;
+  padding: 16px 16px 18px;
+  box-shadow: var(--mob-shadow-card);
+  border: .5px solid var(--mob-line);
+}
+.mob-card-h {
+  font-family: var(--mob-mono);
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--mob-green-ink);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  white-space: nowrap;
+  gap: 10px;
+}
+
+.mob-kv-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px 14px; margin-top: 14px; }
+.mob-kv .mob-k {
+  font-family: var(--mob-mono);
+  font-size: 10.5px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--mob-ink-3);
+}
+.mob-kv .mob-v {
+  font-size: 17px;
+  font-weight: 700;
+  color: var(--mob-ink);
+  margin-top: 3px;
+}
+.mob-kv .mob-v.sm { font-size: 15px; font-weight: 600; }
+
+.mob-grow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px 12px 0;
+  position: relative;
+  cursor: pointer;
+  background: var(--mob-paper);
+  transition: background .12s ease;
+}
+.mob-grow:active { background: #f3f6f4; }
+.mob-grow .mob-bar    { width: 4px; align-self: stretch; border-radius: 0 3px 3px 0; flex: 0 0 4px; }
+.mob-grow .mob-thumb  { flex: 0 0 38px; }
+.mob-grow .mob-meta   { flex: 1; min-width: 0; }
+.mob-grow .mob-gname  {
+  font-family: var(--mob-sans);
+  font-weight: 800;
+  font-size: 16px;
+  color: var(--mob-ink);
+  letter-spacing: -.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.mob-grow .mob-loc {
+  font-family: var(--mob-mono);
+  font-weight: 400;
+  font-size: 12.5px;
+  color: var(--mob-ink-3);
+  margin-left: 7px;
+}
+.mob-grow .mob-gfunc {
+  font-size: 13px;
+  color: var(--mob-ink-2);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.mob-grow .mob-star   { flex: 0 0 auto; background: none; border: none; padding: 8px 4px; cursor: pointer; color: var(--mob-ink-3); line-height: 1; }
+.mob-grow .mob-star.on { color: #e8b400; }
+.mob-grow .mob-chev   { flex: 0 0 auto; color: #c8cec9; }
+.mob-grow .mob-sep    { position: absolute; left: 54px; right: 16px; bottom: 0; height: .5px; background: var(--mob-line); }
+
+.mob-stile {
+  width: 38px; height: 38px;
+  border-radius: 9px;
+  overflow: hidden;
+  background: #f2f4f6;
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,.04);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.mob-stile img { width: 100%; height: 100%; object-fit: cover; }
+
+.mob-chip-row {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding: 2px 16px;
+  scrollbar-width: none;
+}
+.mob-chip-row::-webkit-scrollbar { display: none; }
+.mob-chip {
+  flex: 0 0 auto;
+  font-family: var(--mob-sans);
+  font-weight: 700;
+  font-size: 13px;
+  padding: 7px 13px;
+  border-radius: 999px;
+  border: 1.5px solid var(--mob-line);
+  background: var(--mob-paper);
+  color: var(--mob-ink-2);
+  cursor: pointer;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition: all .12s ease;
+}
+.mob-chip:active { transform: scale(.95); }
+.mob-chip.active { background: var(--mob-ink); color: #fff; border-color: var(--mob-ink); }
+.mob-chip .mob-dot { width: 9px; height: 9px; border-radius: 3px; flex-shrink: 0; }
+
+.mob-seg {
+  display: inline-flex;
+  background: #eef1ee;
+  border-radius: 999px;
+  padding: 3px;
+  gap: 0;
+  flex-shrink: 0;
+}
+.mob-seg-btn {
+  font-family: var(--mob-sans);
+  font-weight: 700;
+  font-size: 12.5px;
+  padding: 5px 12px;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  background: transparent;
+  color: var(--mob-ink-3);
+  white-space: nowrap;
+  transition: all .15s;
+}
+.mob-seg-btn.active {
+  background: var(--mob-paper);
+  color: var(--mob-ink);
+  box-shadow: 0 1px 3px rgba(0,0,0,.10);
+}
+
+.mob-section-h {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  font-family: var(--mob-mono);
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--mob-ink-3);
+  background: rgba(244,246,244,.92);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  padding: 8px 20px 7px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border-bottom: .5px solid var(--mob-line);
+}
+.mob-section-h .mob-sh-count { color: var(--mob-ink-3); font-weight: 400; }
+
+/* ── Bottom-sheet and overlay styles ── */
+.mob-sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  background: rgba(15,25,20,.34);
+  display: flex;
+  align-items: flex-end;
+  animation: mob-fadeup .2s ease;
+}
+.mob-sheet {
+  width: 100%;
+  background: #fff;
+  border-radius: 26px 26px 0 0;
+  padding: 10px 16px calc(env(safe-area-inset-bottom, 14px) + 12px);
+  box-shadow: 0 -8px 30px rgba(0,0,0,.2);
+  max-height: 80vh;
+  overflow-y: auto;
+}
+.mob-sheet-handle {
+  width: 38px;
+  height: 5px;
+  border-radius: 9px;
+  background: #dadfdb;
+  margin: 4px auto 12px;
+}
+.mob-sheet-caption {
+  font-family: var(--mob-mono);
+  font-size: 11px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--mob-ink-3);
+  padding: 2px 6px 10px;
+}
+
+#mob-detail {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: var(--mob-bg);
+  transform: translateX(100%);
+  transition: transform .34s cubic-bezier(.32,.72,0,1);
+  will-change: transform;
+  box-shadow: -8px 0 24px rgba(20,40,30,.10);
+  overflow: hidden;
+}
+#mob-detail.open { transform: translateX(0); }
+#mob-detail-scroll {
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-y: contain;
+  scrollbar-width: none;
+  padding-top: var(--mob-nav-h);
+  padding-bottom: calc(var(--mob-tab-h) + 8px);
+}
+#mob-detail-scroll::-webkit-scrollbar { display: none; }
+
+#mob-search {
+  position: fixed;
+  inset: 0;
+  z-index: 85;
+  background: var(--mob-bg);
+  transform: translateX(100%);
+  transition: transform .34s cubic-bezier(.32,.72,0,1);
+  will-change: transform;
+  overflow: hidden;
+}
+#mob-search.open { transform: translateX(0); }
+#mob-search-scroll {
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  padding-top: var(--mob-nav-h);
+  padding-bottom: calc(var(--mob-tab-h) + 8px);
+}
+#mob-search-scroll::-webkit-scrollbar { display: none; }
+
+/* ── Detail header zone and tag pill styles ── */
+.mob-detail-header {
+  padding: 14px 20px 16px;
+}
+.mob-d-head {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  margin-bottom: 10px;
+}
+.mob-d-thumb {
+  width: 56px;
+  height: 56px;
+  border-radius: 12px;
+  flex-shrink: 0;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.mob-d-thumb img { width: 100%; height: 100%; object-fit: cover; }
+.mob-d-title-block { flex: 1; min-width: 0; }
+.mob-d-title {
+  font-family: var(--mob-sans);
+  font-weight: 800;
+  font-size: 27px;
+  letter-spacing: -.02em;
+  color: var(--mob-ink);
+  line-height: 1.05;
+}
+.mob-d-loc {
+  font-family: var(--mob-mono);
+  font-weight: 400;
+  font-size: 14px;
+  color: var(--mob-ink-3);
+  display: block;
+  margin-top: 4px;
+}
+.mob-d-actions { display: flex; gap: 8px; align-items: center; flex-shrink: 0; }
+
+.mob-tag {
+  font-family: var(--mob-sans);
+  font-weight: 800;
+  font-size: 11px;
+  letter-spacing: .03em;
+  padding: 5px 10px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  white-space: nowrap;
+  border: 1.5px solid currentColor;
+  display: inline-flex;
+  align-items: center;
+}
+.mob-tags-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+.mob-meta-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--mob-ink-3);
+}
+
+.mob-copybtn {
+  font-family: var(--mob-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: .04em;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--mob-line);
+  background: var(--mob-bg-warm);
+  color: var(--mob-ink-2);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  white-space: nowrap;
+  text-decoration: none;
+}
+.mob-copybtn:active { background: #eef1ee; }
+
+/* ── Animation keyframes ── */
+@keyframes mob-fadeup {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: none; }
+}
+@keyframes mob-star-pop {
+  0%   { transform: scale(1); }
+  40%  { transform: scale(1.5); }
+  100% { transform: scale(1); }
+}
+.mob-star-pop { animation: mob-star-pop .3s ease; }

--- a/web/css/mobile.css
+++ b/web/css/mobile.css
@@ -133,6 +133,8 @@
   height: var(--mob-tab-h);
   padding: 6px 4px env(safe-area-inset-bottom, 12px) !important;
   align-items: stretch !important;
+  /* Sit above the detail overlay (z-60) so nav is always reachable */
+  z-index: 70 !important;
 }
 
 .mob-tab-btn {
@@ -750,7 +752,7 @@
   grid-auto-flow: column;
   grid-template-rows: 22px 30px 0px 30px 22px;
   align-items: center;
-  padding: 0 40px;
+  padding: 0 20px;
   min-width: max-content;
 }
 .mob-ctx-track::before {

--- a/web/css/mobile.css
+++ b/web/css/mobile.css
@@ -36,7 +36,7 @@
   --mob-r-md:   16px;
   --mob-r-sm:   12px;
   --mob-nav-h:  52px;
-  --mob-tab-h:  84px;
+  --mob-tab-h:  70px;
 
   /* Shadows */
   --mob-shadow-card: 0 1px 2px rgba(20,40,30,.05), 0 6px 16px rgba(20,40,30,.04);
@@ -131,7 +131,7 @@
   -webkit-backdrop-filter: saturate(180%) blur(22px) !important;
   border-top: 1px solid rgba(0,0,0,.10) !important;
   height: var(--mob-tab-h);
-  padding: 8px 4px env(safe-area-inset-bottom, 14px) !important;
+  padding: 6px 4px env(safe-area-inset-bottom, 12px) !important;
   align-items: stretch !important;
 }
 

--- a/web/css/mobile.css
+++ b/web/css/mobile.css
@@ -547,3 +547,340 @@
   100% { transform: scale(1); }
 }
 .mob-star-pop { animation: mob-star-pop .3s ease; }
+
+/* =========================================================
+   HOME — mobile-specific
+   ========================================================= */
+
+.mob-hero {
+  background: var(--mob-pine);
+  border-radius: 0 0 30px 30px;
+  color: #fff;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 8px 24px rgba(20,40,30,.14);
+}
+.mob-hero-inner {
+  padding: calc(var(--mob-nav-h) + 16px) 22px 42px;
+  position: relative;
+  z-index: 1;
+}
+.mob-hero-eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--mob-mono);
+  font-size: 11px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,.66);
+  white-space: nowrap;
+  margin-bottom: 6px;
+}
+.mob-hero h1 {
+  font-family: var(--mob-serif);
+  font-weight: 700;
+  font-size: 46px;
+  letter-spacing: -.02em;
+  margin: 0 0 10px;
+  line-height: 1;
+  color: #fff;
+}
+.mob-hero p {
+  color: rgba(255,255,255,.78);
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.mob-hero-stats {
+  display: flex;
+  gap: 8px;
+  margin: -22px 16px 0;
+  position: relative;
+  z-index: 2;
+}
+.mob-hstat {
+  flex: 1;
+  background: var(--mob-paper);
+  border-radius: 18px;
+  padding: 14px 12px 12px;
+  box-shadow: var(--mob-shadow-card);
+  border: .5px solid var(--mob-line);
+}
+.mob-hstat .n {
+  font-family: var(--mob-serif);
+  font-weight: 700;
+  font-size: 26px;
+  color: var(--mob-ink);
+  line-height: 1;
+}
+.mob-hstat .l {
+  font-family: var(--mob-mono);
+  font-size: 10px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--mob-ink-3);
+  margin-top: 5px;
+}
+
+.mob-home-sec-h {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 24px 22px 10px;
+}
+.mob-home-sec-h .t {
+  font-family: var(--mob-mono);
+  font-weight: 600;
+  font-size: 12.5px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--mob-green-ink);
+}
+.mob-home-sec-h .more {
+  margin-left: auto;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--mob-green);
+  cursor: pointer;
+  background: none;
+  border: none;
+}
+
+.mob-strain-card {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  background: var(--mob-card);
+  border-radius: 18px;
+  margin: 0 16px 10px;
+  padding: 14px;
+  box-shadow: var(--mob-shadow-card);
+  border: .5px solid var(--mob-line);
+  position: relative;
+  overflow: hidden;
+  cursor: pointer;
+  transition: transform .1s ease;
+}
+.mob-strain-card:active { transform: scale(.99); }
+.mob-strain-card .sbar { position: absolute; left: 0; top: 0; bottom: 0; width: 5px; }
+.mob-strain-card .sicon { width: 40px; height: 40px; object-fit: contain; flex-shrink: 0; }
+.mob-strain-card .scode { font-family: var(--mob-sans); font-weight: 800; font-size: 17px; }
+.mob-strain-card .sname { font-style: italic; font-size: 13.5px; color: var(--mob-ink-2); margin-top: 1px; }
+.mob-strain-card .scount { font-size: 12.5px; color: var(--mob-ink-3); margin-top: 3px; }
+
+.mob-minirow {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  background: var(--mob-card);
+  border-radius: 16px;
+  margin: 0 16px 9px;
+  padding: 12px 14px;
+  box-shadow: var(--mob-shadow-card);
+  border: .5px solid var(--mob-line);
+  cursor: pointer;
+  transition: transform .1s ease;
+}
+.mob-minirow:active { transform: scale(.99); }
+.mob-minirow .mn { font-family: var(--mob-sans); font-weight: 800; font-size: 15.5px; color: var(--mob-ink); }
+.mob-minirow .ms { font-size: 12.5px; color: var(--mob-ink-3); margin-top: 1px; }
+
+.mob-map-card {
+  margin: 0 16px;
+  border-radius: 18px;
+  overflow: hidden;
+  border: .5px solid var(--mob-line);
+  background: #eef1f4;
+  height: 150px;
+  position: relative;
+  box-shadow: var(--mob-shadow-card);
+}
+
+/* =========================================================
+   GENOMIC CONTEXT TRACK
+   ========================================================= */
+
+.mob-ctx-wrap { position: relative; margin-top: 6px; }
+
+.mob-ctx-scroll {
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  padding: 6px 0 4px;
+}
+.mob-ctx-scroll::-webkit-scrollbar { display: none; }
+
+.mob-ctx-track {
+  position: relative;
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-rows: 22px 30px 0px 30px 22px;
+  align-items: center;
+  padding: 0 40px;
+  min-width: max-content;
+}
+.mob-ctx-track::before {
+  content: '';
+  position: absolute;
+  left: 0; right: 0;
+  top: 50%;
+  height: 2px;
+  background: #dfe4e0;
+  transform: translateY(-1px);
+  pointer-events: none;
+}
+
+.mob-ctx-col {
+  display: grid;
+  grid-template-rows: subgrid;
+  grid-row: 1 / 6;
+  padding: 0 3px;
+}
+
+.mob-ctx-lab {
+  font-size: 11px;
+  color: var(--mob-ink-2);
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 120px;
+}
+.mob-ctx-lab .sym { font-weight: 800; color: var(--mob-ink); }
+.mob-ctx-lab.mono { font-family: var(--mob-mono); font-size: 10px; color: var(--mob-ink-3); }
+
+.mob-ctx-arrow-slot { display: flex; align-items: center; }
+.mob-ctx-arrow-slot.plus  { align-items: flex-end; }
+.mob-ctx-arrow-slot.minus { align-items: flex-start; }
+
+.mob-ctx-center { height: 0; }
+
+.mob-ctx-arrow {
+  height: 26px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  z-index: 2;
+}
+.mob-ctx-arrow .body {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  box-shadow: inset 0 -2px 0 rgba(0,0,0,.08);
+}
+.mob-ctx-arrow.plus  .body { clip-path: polygon(0 0, calc(100% - 11px) 0, 100% 50%, calc(100% - 11px) 100%, 0 100%); }
+.mob-ctx-arrow.minus .body { clip-path: polygon(11px 0, 100% 0, 100% 100%, 11px 100%, 0 50%); }
+.mob-ctx-col.focal .mob-ctx-arrow .body {
+  box-shadow: inset 0 0 0 2px var(--mob-ink), inset 0 -2px 0 rgba(0,0,0,.12);
+}
+
+.mob-ctx-strand {
+  position: absolute;
+  left: 8px;
+  font-family: var(--mob-mono);
+  font-size: 11px;
+  color: var(--mob-ink-3);
+  z-index: 3;
+  pointer-events: none;
+}
+.mob-ctx-strand.p { top: 26px; }
+.mob-ctx-strand.m { bottom: 26px; }
+
+.mob-ctx-fade {
+  position: absolute;
+  top: 0; bottom: 0;
+  width: 28px;
+  pointer-events: none;
+  z-index: 4;
+}
+.mob-ctx-fade.l { left: 0;  background: linear-gradient(90deg,  var(--mob-paper), rgba(255,255,255,0)); }
+.mob-ctx-fade.r { right: 0; background: linear-gradient(270deg, var(--mob-paper), rgba(255,255,255,0)); }
+
+.mob-ctx-hint {
+  position: absolute;
+  right: 10px; bottom: 0;
+  z-index: 5;
+  font-family: var(--mob-mono);
+  font-size: 10px;
+  letter-spacing: .04em;
+  color: var(--mob-ink-3);
+  background: rgba(255,255,255,.85);
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: .5px solid var(--mob-line);
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  transition: opacity .3s ease;
+  pointer-events: none;
+}
+
+/* =========================================================
+   GENOMES LIST — sticky toolbar + search + strain context
+   ========================================================= */
+
+.mob-sticky-bar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: rgba(244,246,244,.94);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border-bottom: .5px solid var(--mob-line);
+  padding: 10px 16px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mob-search-field {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  background: #fff;
+  border: 1px solid var(--mob-line);
+  border-radius: 13px;
+  padding: 0 12px;
+  height: 42px;
+}
+.mob-search-field input {
+  border: none;
+  outline: none;
+  flex: 1;
+  font-family: var(--mob-sans);
+  font-size: 15px;
+  background: transparent;
+  color: var(--mob-ink);
+}
+.mob-search-field input::placeholder { color: var(--mob-ink-3); }
+
+.mob-strain-ctx {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 20px 12px;
+}
+.mob-strain-ctx img { width: 34px; height: 34px; object-fit: contain; flex-shrink: 0; }
+.mob-strain-ctx .spc { font-style: italic; font-weight: 600; font-size: 15px; color: var(--mob-ink); }
+.mob-strain-ctx .cnt { font-size: 13px; color: var(--mob-ink-3); margin-top: 1px; }
+.mob-switch-btn {
+  margin-left: auto;
+  font-family: var(--mob-mono);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 11px;
+  border-radius: 8px;
+  border: 1px solid var(--mob-line);
+  background: var(--mob-bg-warm);
+  color: var(--mob-ink-2);
+  cursor: pointer;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.mob-switch-btn:active { background: #eef1ee; }

--- a/web/css/mobile.css
+++ b/web/css/mobile.css
@@ -898,7 +898,7 @@
   padding: 10px 20px 12px;
 }
 .mob-strain-ctx img { width: 34px; height: 34px; object-fit: contain; flex-shrink: 0; }
-.mob-strain-ctx .spc { font-style: italic; font-weight: 600; font-size: 15px; color: var(--mob-ink); }
+.mob-strain-ctx .spc { font-weight: 600; font-size: 15px; color: var(--mob-ink); }
 .mob-strain-ctx .cnt { font-size: 13px; color: var(--mob-ink-3); margin-top: 1px; }
 .mob-switch-btn {
   margin-left: auto;

--- a/web/css/mobile.css
+++ b/web/css/mobile.css
@@ -154,8 +154,33 @@
   font-weight: 700;
   letter-spacing: .01em;
 }
-.mob-tab-btn.active { color: var(--mob-green); }
-.mob-tab-btn:active { transform: scale(.93); }
+.mob-tab-btn.active  { color: var(--mob-green); }
+.mob-tab-btn:active  { transform: scale(.93); }
+
+/* PNG tab icons — CSS filter colorizes the black silhouettes */
+.mob-tab-icon {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+  display: block;
+  /* Inactive: dark gray-green (#4a5650) */
+  filter: brightness(0) saturate(100%) invert(30%) sepia(10%) saturate(400%) hue-rotate(120deg) brightness(85%);
+  transition: filter .15s;
+}
+.mob-tab-btn.active .mob-tab-icon {
+  /* Active: brand green (#2f9e6e) */
+  filter: brightness(0) saturate(100%) invert(52%) sepia(50%) saturate(500%) hue-rotate(111deg) brightness(90%);
+}
+
+/* Section-header PNG icons (green #277a55) */
+.mob-sec-icon {
+  width: 16px;
+  height: 16px;
+  object-fit: contain;
+  display: block;
+  filter: brightness(0) saturate(100%) invert(40%) sepia(43%) saturate(500%) hue-rotate(112deg) brightness(82%);
+  flex-shrink: 0;
+}
 
 /* ── Page/screen layout utilities ── */
 @media (max-width: 639px) {

--- a/web/css/mobile.css
+++ b/web/css/mobile.css
@@ -48,6 +48,15 @@
   box-sizing: border-box;
 }
 
+/* ── Force mobile-only shell elements hidden on desktop ── */
+@media (min-width: 640px) {
+  #mob-bar,
+  #mob-nav-left,
+  #mob-nav-right,
+  #mob-detail,
+  #mob-search { display: none !important; }
+}
+
 /* ── Collapsing nav bar styles ── */
 #mob-bar {
   position: fixed;
@@ -554,11 +563,10 @@
 
 .mob-hero {
   background: var(--mob-pine);
-  border-radius: 0 0 30px 30px;
+  border-radius: 0;
   color: #fff;
   position: relative;
   overflow: hidden;
-  box-shadow: 0 8px 24px rgba(20,40,30,.14);
 }
 .mob-hero-inner {
   padding: calc(var(--mob-nav-h) + 16px) 22px 42px;

--- a/web/css/mobile.css
+++ b/web/css/mobile.css
@@ -125,10 +125,10 @@
 
 /* ── Bottom tab bar styles ── */
 #mobile-nav {
-  background: rgba(252,253,252,.88) !important;
+  background: rgba(252,253,252,.94) !important;
   backdrop-filter: saturate(180%) blur(22px) !important;
   -webkit-backdrop-filter: saturate(180%) blur(22px) !important;
-  border-top: .5px solid var(--mob-line) !important;
+  border-top: 1px solid rgba(0,0,0,.10) !important;
   height: var(--mob-tab-h);
   padding: 8px 4px env(safe-area-inset-bottom, 14px) !important;
   align-items: stretch !important;
@@ -144,7 +144,7 @@
   background: none;
   border: none;
   cursor: pointer;
-  color: var(--mob-ink-3);
+  color: var(--mob-ink-2);
   padding: 4px 0;
   transition: color .15s;
   font-family: var(--mob-sans);
@@ -160,6 +160,9 @@
 /* ── Page/screen layout utilities ── */
 @media (max-width: 639px) {
   main { padding-top: var(--mob-nav-h) !important; }
+
+  /* Home hero bleeds edge-to-edge; hero inner padding clears nav bar */
+  #tab-home.tab-panel { top: 0 !important; }
 
   .tab-panel {
     position: fixed !important;

--- a/web/css/mobile.css
+++ b/web/css/mobile.css
@@ -425,7 +425,7 @@
   position: fixed;
   inset: 0;
   z-index: 60;
-  background: var(--mob-bg);
+  background: #fff;
   transform: translateX(100%);
   transition: transform .34s cubic-bezier(.32,.72,0,1);
   will-change: transform;
@@ -443,7 +443,37 @@
   scrollbar-width: none;
   padding-top: var(--mob-nav-h);
   padding-bottom: calc(var(--mob-tab-h) + 8px);
+  background: #fff;
 }
+
+/* ── Gene detail: section layout (card-free) ── */
+.mob-det-sec {
+  padding: 18px 16px 20px;
+  border-top: 1px solid var(--mob-line);
+}
+.mob-det-h {
+  font-family: var(--mob-sans);
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--mob-green-ink);
+  margin-bottom: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+/* Contained card (structure viewer, localization diagram) */
+.mob-det-card {
+  background: var(--mob-bg-warm);
+  border-radius: 14px;
+  border: .5px solid var(--mob-line);
+  overflow: hidden;
+}
+/* Gene map: flush full-width, horizontally scrollable */
+.mob-det-sec--map {
+  padding: 18px 0 20px;
+}
+.mob-det-sec--map .mob-det-h { padding: 0 16px; }
 #mob-detail-scroll::-webkit-scrollbar { display: none; }
 
 /* Search — bottom sheet (slides up from bottom) */
@@ -752,7 +782,7 @@
   grid-auto-flow: column;
   grid-template-rows: 22px 30px 0px 30px 22px;
   align-items: center;
-  padding: 0 20px;
+  padding: 0 16px;
   min-width: max-content;
 }
 .mob-ctx-track::before {

--- a/web/css/mobile.css
+++ b/web/css/mobile.css
@@ -82,9 +82,9 @@
   pointer-events: auto;
 }
 #mob-bar-title {
-  font-family: var(--mob-serif);
-  font-weight: 600;
-  font-size: 17px;
+  font-family: var(--mob-sans);
+  font-weight: 700;
+  font-size: 16px;
   color: var(--mob-ink);
   max-width: 58%;
   overflow: hidden;

--- a/web/index.html
+++ b/web/index.html
@@ -176,24 +176,45 @@
 
   <!-- ─── MOBILE BOTTOM NAV ─────────────────────────────────── -->
   <nav class="sm:hidden fixed bottom-0 left-0 right-0 z-50 flex safe-area-pb" id="mobile-nav">
+    <!-- Home -->
     <button data-tab="home" class="mob-tab-btn active">
-      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M3 11L12 3l9 8v9a1 1 0 0 1-1 1H15v-6H9v6H4a1 1 0 0 1-1-1v-9z"/>
+      </svg>
       <span class="mob-tab-label">Home</span>
     </button>
+    <!-- Genomes — clean DNA double helix -->
     <button data-tab="genomes" class="mob-tab-btn">
-      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 16.1A5 5 0 0 1 5.5 8h.5a6 6 0 0 1 6-6 6 6 0 0 1 6 6h.5a5 5 0 0 1 3.5 8.4"/><path d="m12 12 4 10"/><path d="m12 12-4 10"/><path d="M12 2v10"/></svg>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+        <path d="M5 3c0 5 5 5 7 9s7 4 7 9"/>
+        <path d="M19 3c0 5-5 5-7 9s-7 4-7 9"/>
+        <line x1="5" y1="9" x2="19" y2="9"/>
+        <line x1="5" y1="15" x2="19" y2="15"/>
+      </svg>
       <span class="mob-tab-label">Genomes</span>
     </button>
+    <!-- Mutants — lightning bolt -->
     <button data-tab="mutants" class="mob-tab-btn">
-      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 3H5a2 2 0 0 0-2 2v4"/><path d="M9 3h6"/><path d="M15 3h4a2 2 0 0 1 2 2v4"/><path d="M3 9v6"/><path d="M21 9v6"/><path d="M3 15v4a2 2 0 0 0 2 2h4"/><path d="M15 21h4a2 2 0 0 0 2-2v-4"/><path d="M9 21h6"/><circle cx="12" cy="12" r="3"/></svg>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M13 2L4 13h7l-1 9 10-12h-7z"/>
+      </svg>
       <span class="mob-tab-label">Mutants</span>
     </button>
+    <!-- Pipeline — ascending bars -->
     <button data-tab="pipeline" class="mob-tab-btn" id="mob-tab-pipeline" style="display:none">
-      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="3" y="14" width="4" height="7" rx="1"/>
+        <rect x="10" y="9" width="4" height="12" rx="1"/>
+        <rect x="17" y="4" width="4" height="17" rx="1"/>
+      </svg>
       <span class="mob-tab-label">Pipeline</span>
     </button>
+    <!-- Tools — flask -->
     <button data-tab="tools" class="mob-tab-btn" id="mob-tab-tools">
-      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 3H7a2 2 0 0 0-2 2v2"/><path d="M15 3h2a2 2 0 0 1 2 2v2"/><path d="M5 21v-2a2 2 0 0 1 2-2h2"/><path d="M19 21v-2a2 2 0 0 1-2-2h-2"/><rect x="9" y="9" width="6" height="6" rx="1"/></svg>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M9 3h6M9 3v6l-5 9a1 1 0 0 0 .9 1.5h14.2A1 1 0 0 0 20 18l-5-9V3"/>
+        <line x1="6.5" y1="15" x2="17.5" y2="15"/>
+      </svg>
       <span class="mob-tab-label">Tools</span>
     </button>
   </nav>

--- a/web/index.html
+++ b/web/index.html
@@ -38,6 +38,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@700&family=DM+Sans:wght@400;500;600&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet" />
 
   <link rel="stylesheet" href="/web/css/app.css?v=80" />
+  <link rel="stylesheet" href="/web/css/mobile.css?v=1" />
   <link rel="stylesheet" href="/web/css/pipeline.css">
   <!-- Leaflet (community world map) -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.min.css"/>
@@ -45,7 +46,7 @@
 <body class="bg-white text-gray-900 font-sans min-h-screen">
 
   <!-- ─── TOP NAV ─────────────────────────────────────────── -->
-  <header class="sticky top-0 z-50 shadow-md" style="background:#0f4530;">
+  <header class="hidden sm:sticky sm:top-0 sm:z-50 sm:shadow-md sm:block" style="background:#0f4530;">
     <div class="max-w-6xl mx-auto px-4 flex items-center justify-between h-14 gap-4">
 
       <!-- Logo / wordmark -->
@@ -103,6 +104,27 @@
     </div>
   </header>
 
+  <!-- ─── MOBILE COLLAPSING NAV BAR ──────────────────────────── -->
+  <div id="mob-bar" class="sm:hidden" aria-hidden="true">
+    <span id="mob-bar-title">ChlamAtlas</span>
+  </div>
+
+  <!-- Left nav area: Back button appears here when a detail is open -->
+  <div id="mob-nav-left" class="sm:hidden"></div>
+
+  <!-- Right nav area: Search, Saved, Account glass buttons -->
+  <div id="mob-nav-right" class="sm:hidden">
+    <button class="mob-gbtn" id="mob-btn-search" aria-label="Search">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+    </button>
+    <button class="mob-gbtn" id="mob-btn-saved" aria-label="Saved">
+      <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+    </button>
+    <button class="mob-gbtn" id="mob-btn-account" aria-label="Account">
+      <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="8" r="4"/><path d="M4 20c1.5-4 5-5 8-5s6.5 1 8 5"/></svg>
+    </button>
+  </div>
+
   <!-- ─── MAIN CONTENT ─────────────────────────────────────── -->
   <main class="pb-24 sm:pb-8">
 
@@ -153,27 +175,26 @@
   </main>
 
   <!-- ─── MOBILE BOTTOM NAV ─────────────────────────────────── -->
-  <nav class="sm:hidden fixed bottom-0 left-0 right-0 z-50 bg-white border-t border-gray-100 flex safe-area-pb" id="mobile-nav">
-    <button data-tab="home" class="mobile-tab active flex-1">
-      <span class="tab-icon-wrap">
-        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
-      </span>
-      <span class="text-[10px] font-medium mt-0.5">Home</span>
+  <nav class="sm:hidden fixed bottom-0 left-0 right-0 z-50 flex safe-area-pb" id="mobile-nav">
+    <button data-tab="home" class="mob-tab-btn active">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+      <span class="mob-tab-label">Home</span>
     </button>
-    <button data-tab="genomes" class="mobile-tab flex-1">
-      <span class="tab-icon-wrap">
-        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 16.1A5 5 0 0 1 5.5 8h.5a6 6 0 0 1 6-6 6 6 0 0 1 6 6h.5a5 5 0 0 1 3.5 8.4"/><path d="m12 12 4 10"/><path d="m12 12-4 10"/><path d="M12 2v10"/></svg>
-      </span>
-      <span class="text-[10px] font-medium mt-0.5">Genomes</span>
+    <button data-tab="genomes" class="mob-tab-btn">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 16.1A5 5 0 0 1 5.5 8h.5a6 6 0 0 1 6-6 6 6 0 0 1 6 6h.5a5 5 0 0 1 3.5 8.4"/><path d="m12 12 4 10"/><path d="m12 12-4 10"/><path d="M12 2v10"/></svg>
+      <span class="mob-tab-label">Genomes</span>
     </button>
-    <button data-tab="mutants" class="mobile-tab flex-1">
-      <span class="tab-icon-wrap">
-        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 3H5a2 2 0 0 0-2 2v4"/><path d="M9 3h6"/><path d="M15 3h4a2 2 0 0 1 2 2v4"/><path d="M3 9v6"/><path d="M21 9v6"/><path d="M3 15v4a2 2 0 0 0 2 2h4"/><path d="M15 21h4a2 2 0 0 0 2-2v-4"/><path d="M9 21h6"/><circle cx="12" cy="12" r="3"/></svg>
-      </span>
-      <span class="text-[10px] font-medium mt-0.5">Mutants</span>
+    <button data-tab="mutants" class="mob-tab-btn">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 3H5a2 2 0 0 0-2 2v4"/><path d="M9 3h6"/><path d="M15 3h4a2 2 0 0 1 2 2v4"/><path d="M3 9v6"/><path d="M21 9v6"/><path d="M3 15v4a2 2 0 0 0 2 2h4"/><path d="M15 21h4a2 2 0 0 0 2-2v-4"/><path d="M9 21h6"/><circle cx="12" cy="12" r="3"/></svg>
+      <span class="mob-tab-label">Mutants</span>
     </button>
-    <button data-tab="pipeline" class="mobile-tab flex-1" style="display:none">
-      <span class="text-[10px] font-medium mt-0.5">Pipeline</span>
+    <button data-tab="pipeline" class="mob-tab-btn" id="mob-tab-pipeline" style="display:none">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
+      <span class="mob-tab-label">Pipeline</span>
+    </button>
+    <button data-tab="tools" class="mob-tab-btn" id="mob-tab-tools">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 3H7a2 2 0 0 0-2 2v2"/><path d="M15 3h2a2 2 0 0 1 2 2v2"/><path d="M5 21v-2a2 2 0 0 1 2-2h2"/><path d="M19 21v-2a2 2 0 0 1-2-2h-2"/><rect x="9" y="9" width="6" height="6" rx="1"/></svg>
+      <span class="mob-tab-label">Tools</span>
     </button>
   </nav>
 
@@ -364,6 +385,32 @@
           Change password →
         </button>
       </div>
+    </div>
+  </div>
+
+  <!-- ─── MOBILE DETAIL OVERLAY (gene / mutant push layer) ── -->
+  <div id="mob-detail" class="sm:hidden" aria-modal="true" role="dialog" aria-label="Detail">
+    <div id="mob-detail-scroll"></div>
+  </div>
+
+  <!-- ─── MOBILE SEARCH OVERLAY ──────────────────────────────── -->
+  <div id="mob-search" class="sm:hidden" aria-modal="true" role="search" aria-label="Search">
+    <div id="mob-search-scroll">
+      <div style="padding: 12px 16px 8px; display:flex; align-items:center; gap:10px;">
+        <button class="mob-gbtn" id="mob-search-back" aria-label="Close search">
+          <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><polyline points="15 18 9 12 15 6"/></svg>
+        </button>
+        <h2 style="font-family:var(--mob-serif);font-weight:700;font-size:28px;color:var(--mob-ink);margin:0;">Search</h2>
+      </div>
+      <div style="padding: 6px 16px 10px;">
+        <div style="display:flex;align-items:center;gap:9px;background:#fff;border:1px solid var(--mob-line);border-radius:13px;padding:0 12px;height:44px;">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#9aa39c" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          <input id="mob-search-input" type="search" autocomplete="off"
+            placeholder="Genes, locus tags, products…"
+            style="border:none;outline:none;flex:1;font-family:var(--mob-sans);font-size:15px;background:transparent;color:var(--mob-ink);" />
+        </div>
+      </div>
+      <div id="mob-search-results"></div>
     </div>
   </div>
 

--- a/web/index.html
+++ b/web/index.html
@@ -419,6 +419,6 @@
   <!-- Supabase JS client (ESM via CDN) -->
   <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.min.js"></script>
   <script src="/web/js/chlam-globe-bg.js"></script>
-  <script type="module" src="/web/js/app.js?v=86"></script>
+  <script type="module" src="/web/js/app.js?v=87"></script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -419,6 +419,6 @@
   <!-- Supabase JS client (ESM via CDN) -->
   <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.min.js"></script>
   <script src="/web/js/chlam-globe-bg.js"></script>
-  <script type="module" src="/web/js/app.js?v=85"></script>
+  <script type="module" src="/web/js/app.js?v=86"></script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -419,6 +419,6 @@
   <!-- Supabase JS client (ESM via CDN) -->
   <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.min.js"></script>
   <script src="/web/js/chlam-globe-bg.js"></script>
-  <script type="module" src="/web/js/app.js?v=89"></script>
+  <script type="module" src="/web/js/app.js?v=90"></script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -419,6 +419,6 @@
   <!-- Supabase JS client (ESM via CDN) -->
   <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.min.js"></script>
   <script src="/web/js/chlam-globe-bg.js"></script>
-  <script type="module" src="/web/js/app.js?v=90"></script>
+  <script type="module" src="/web/js/app.js?v=91"></script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -118,7 +118,7 @@
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
     </button>
     <button class="mob-gbtn" id="mob-btn-saved" aria-label="Saved">
-      <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+      <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
     </button>
     <button class="mob-gbtn" id="mob-btn-account" aria-label="Account">
       <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="8" r="4"/><path d="M4 20c1.5-4 5-5 8-5s6.5 1 8 5"/></svg>

--- a/web/index.html
+++ b/web/index.html
@@ -419,6 +419,6 @@
   <!-- Supabase JS client (ESM via CDN) -->
   <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.min.js"></script>
   <script src="/web/js/chlam-globe-bg.js"></script>
-  <script type="module" src="/web/js/app.js?v=88"></script>
+  <script type="module" src="/web/js/app.js?v=89"></script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -115,13 +115,13 @@
   <!-- Right nav area: Search, Saved, Account glass buttons -->
   <div id="mob-nav-right" class="sm:hidden">
     <button class="mob-gbtn" id="mob-btn-search" aria-label="Search">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 21-4.34-4.34"/><circle cx="11" cy="11" r="8"/></svg>
     </button>
     <button class="mob-gbtn" id="mob-btn-saved" aria-label="Saved">
-      <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+      <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 9.5a5.5 5.5 0 0 1 9.591-3.676.56.56 0 0 0 .818 0A5.49 5.49 0 0 1 22 9.5c0 2.29-1.5 4-3 5.5l-5.492 5.313a2 2 0 0 1-3 .019L5 15c-1.5-1.5-3-3.2-3-5.5"/></svg>
     </button>
     <button class="mob-gbtn" id="mob-btn-account" aria-label="Account">
-      <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="8" r="4"/><path d="M4 20c1.5-4 5-5 8-5s6.5 1 8 5"/></svg>
+      <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.925 20.056a6 6 0 0 0-11.851.001"/><circle cx="12" cy="11" r="4"/><circle cx="12" cy="12" r="10"/></svg>
     </button>
   </div>
 
@@ -177,33 +177,23 @@
   <!-- ─── MOBILE BOTTOM NAV ─────────────────────────────────── -->
   <nav class="sm:hidden fixed bottom-0 left-0 right-0 z-50 flex safe-area-pb" id="mobile-nav">
     <button data-tab="home" class="mob-tab-btn active">
-      <!-- Home: filled house shape -->
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/></svg>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"/><path d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>
       <span class="mob-tab-label">Home</span>
     </button>
     <button data-tab="genomes" class="mob-tab-btn">
-      <!-- Genomes: DNA helix strands with crossbars -->
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-        <path d="M5.5 3c0 5 5 5.5 6.5 8.5S18.5 16 18.5 21"/>
-        <path d="M18.5 3c0 5-5 5.5-6.5 8.5S5.5 16 5.5 21"/>
-        <line x1="5.5" y1="8" x2="18.5" y2="8"/>
-        <line x1="5.5" y1="16" x2="18.5" y2="16"/>
-      </svg>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m10 16 1.5 1.5"/><path d="m14 8-1.5-1.5"/><path d="M15 2c-1.798 1.998-2.518 3.995-2.807 5.993"/><path d="m16.5 10.5 1 1"/><path d="m17 6-2.891-2.891"/><path d="M2 15c6.667-6 13.333 0 20-6"/><path d="m20 9 .891.891"/><path d="M3.109 14.109 4 15"/><path d="m6.5 12.5 1 1"/><path d="m7 18 2.891 2.891"/><path d="M9 22c1.798-1.998 2.518-3.995 2.807-5.993"/></svg>
       <span class="mob-tab-label">Genomes</span>
     </button>
     <button data-tab="mutants" class="mob-tab-btn">
-      <!-- Mutants: solid lightning bolt -->
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M13 2L4.5 13.5H11l-1 8.5L20.5 10H14z"/></svg>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 18h8"/><path d="M3 22h18"/><path d="M14 22a7 7 0 1 0 0-14h-1"/><path d="M9 14h2"/><path d="M9 12a2 2 0 0 1-2-2V6h6v4a2 2 0 0 1-2 2Z"/><path d="M12 6V3a1 1 0 0 0-1-1H9a1 1 0 0 0-1 1v3"/></svg>
       <span class="mob-tab-label">Mutants</span>
     </button>
     <button data-tab="pipeline" class="mob-tab-btn" id="mob-tab-pipeline" style="display:none">
-      <!-- Pipeline: ascending bar chart -->
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="none"><rect x="2" y="14" width="5" height="7" rx="1"/><rect x="9.5" y="9" width="5" height="12" rx="1"/><rect x="17" y="4" width="5" height="17" rx="1"/></svg>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 17V9"/><path d="M18 17V5"/><path d="M3 3v16a2 2 0 0 0 2 2h16"/><path d="M8 17v-3"/></svg>
       <span class="mob-tab-label">Pipeline</span>
     </button>
     <button data-tab="tools" class="mob-tab-btn" id="mob-tab-tools">
-      <!-- Tools: wrench -->
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.106-3.105c.32-.322.863-.22.983.218a6 6 0 0 1-8.259 7.057l-7.91 7.91a1 1 0 0 1-2.999-3l7.91-7.91a6 6 0 0 1 7.057-8.259c.438.12.54.662.219.984z"/></svg>
       <span class="mob-tab-label">Tools</span>
     </button>
   </nav>
@@ -429,6 +419,6 @@
   <!-- Supabase JS client (ESM via CDN) -->
   <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.min.js"></script>
   <script src="/web/js/chlam-globe-bg.js"></script>
-  <script type="module" src="/web/js/app.js?v=84"></script>
+  <script type="module" src="/web/js/app.js?v=85"></script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -176,45 +176,24 @@
 
   <!-- ─── MOBILE BOTTOM NAV ─────────────────────────────────── -->
   <nav class="sm:hidden fixed bottom-0 left-0 right-0 z-50 flex safe-area-pb" id="mobile-nav">
-    <!-- Home -->
     <button data-tab="home" class="mob-tab-btn active">
-      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M3 11L12 3l9 8v9a1 1 0 0 1-1 1H15v-6H9v6H4a1 1 0 0 1-1-1v-9z"/>
-      </svg>
+      <img src="/design/icons_mobile/home.png" class="mob-tab-icon" alt="">
       <span class="mob-tab-label">Home</span>
     </button>
-    <!-- Genomes — clean DNA double helix -->
     <button data-tab="genomes" class="mob-tab-btn">
-      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
-        <path d="M5 3c0 5 5 5 7 9s7 4 7 9"/>
-        <path d="M19 3c0 5-5 5-7 9s-7 4-7 9"/>
-        <line x1="5" y1="9" x2="19" y2="9"/>
-        <line x1="5" y1="15" x2="19" y2="15"/>
-      </svg>
+      <img src="/design/icons_mobile/dna.png" class="mob-tab-icon" alt="">
       <span class="mob-tab-label">Genomes</span>
     </button>
-    <!-- Mutants — lightning bolt -->
     <button data-tab="mutants" class="mob-tab-btn">
-      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M13 2L4 13h7l-1 9 10-12h-7z"/>
-      </svg>
+      <img src="/design/icons_mobile/bolt.png" class="mob-tab-icon" alt="">
       <span class="mob-tab-label">Mutants</span>
     </button>
-    <!-- Pipeline — ascending bars -->
     <button data-tab="pipeline" class="mob-tab-btn" id="mob-tab-pipeline" style="display:none">
-      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-        <rect x="3" y="14" width="4" height="7" rx="1"/>
-        <rect x="10" y="9" width="4" height="12" rx="1"/>
-        <rect x="17" y="4" width="4" height="17" rx="1"/>
-      </svg>
+      <img src="/design/icons_mobile/rocket-lunch.png" class="mob-tab-icon" alt="">
       <span class="mob-tab-label">Pipeline</span>
     </button>
-    <!-- Tools — flask -->
     <button data-tab="tools" class="mob-tab-btn" id="mob-tab-tools">
-      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M9 3h6M9 3v6l-5 9a1 1 0 0 0 .9 1.5h14.2A1 1 0 0 0 20 18l-5-9V3"/>
-        <line x1="6.5" y1="15" x2="17.5" y2="15"/>
-      </svg>
+      <img src="/design/icons_mobile/wrench-alt.png" class="mob-tab-icon" alt="">
       <span class="mob-tab-label">Tools</span>
     </button>
   </nav>

--- a/web/index.html
+++ b/web/index.html
@@ -419,6 +419,6 @@
   <!-- Supabase JS client (ESM via CDN) -->
   <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.min.js"></script>
   <script src="/web/js/chlam-globe-bg.js"></script>
-  <script type="module" src="/web/js/app.js?v=87"></script>
+  <script type="module" src="/web/js/app.js?v=88"></script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -185,7 +185,7 @@
       <span class="mob-tab-label">Genomes</span>
     </button>
     <button data-tab="mutants" class="mob-tab-btn">
-      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 18h8"/><path d="M3 22h18"/><path d="M14 22a7 7 0 1 0 0-14h-1"/><path d="M9 14h2"/><path d="M9 12a2 2 0 0 1-2-2V6h6v4a2 2 0 0 1-2 2Z"/><path d="M12 6V3a1 1 0 0 0-1-1H9a1 1 0 0 0-1 1v3"/></svg>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z"/></svg>
       <span class="mob-tab-label">Mutants</span>
     </button>
     <button data-tab="pipeline" class="mob-tab-btn" id="mob-tab-pipeline" style="display:none">

--- a/web/index.html
+++ b/web/index.html
@@ -177,23 +177,33 @@
   <!-- ─── MOBILE BOTTOM NAV ─────────────────────────────────── -->
   <nav class="sm:hidden fixed bottom-0 left-0 right-0 z-50 flex safe-area-pb" id="mobile-nav">
     <button data-tab="home" class="mob-tab-btn active">
-      <img src="/design/icons_mobile/home.png" class="mob-tab-icon" alt="">
+      <!-- Home: filled house shape -->
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/></svg>
       <span class="mob-tab-label">Home</span>
     </button>
     <button data-tab="genomes" class="mob-tab-btn">
-      <img src="/design/icons_mobile/dna.png" class="mob-tab-icon" alt="">
+      <!-- Genomes: DNA helix strands with crossbars -->
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <path d="M5.5 3c0 5 5 5.5 6.5 8.5S18.5 16 18.5 21"/>
+        <path d="M18.5 3c0 5-5 5.5-6.5 8.5S5.5 16 5.5 21"/>
+        <line x1="5.5" y1="8" x2="18.5" y2="8"/>
+        <line x1="5.5" y1="16" x2="18.5" y2="16"/>
+      </svg>
       <span class="mob-tab-label">Genomes</span>
     </button>
     <button data-tab="mutants" class="mob-tab-btn">
-      <img src="/design/icons_mobile/bolt.png" class="mob-tab-icon" alt="">
+      <!-- Mutants: solid lightning bolt -->
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M13 2L4.5 13.5H11l-1 8.5L20.5 10H14z"/></svg>
       <span class="mob-tab-label">Mutants</span>
     </button>
     <button data-tab="pipeline" class="mob-tab-btn" id="mob-tab-pipeline" style="display:none">
-      <img src="/design/icons_mobile/rocket-lunch.png" class="mob-tab-icon" alt="">
+      <!-- Pipeline: ascending bar chart -->
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="none"><rect x="2" y="14" width="5" height="7" rx="1"/><rect x="9.5" y="9" width="5" height="12" rx="1"/><rect x="17" y="4" width="5" height="17" rx="1"/></svg>
       <span class="mob-tab-label">Pipeline</span>
     </button>
     <button data-tab="tools" class="mob-tab-btn" id="mob-tab-tools">
-      <img src="/design/icons_mobile/wrench-alt.png" class="mob-tab-icon" alt="">
+      <!-- Tools: wrench -->
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
       <span class="mob-tab-label">Tools</span>
     </button>
   </nav>
@@ -393,24 +403,26 @@
     <div id="mob-detail-scroll"></div>
   </div>
 
-  <!-- ─── MOBILE SEARCH OVERLAY ──────────────────────────────── -->
+  <!-- ─── MOBILE SEARCH — bottom sheet ──────────────────────── -->
+  <div id="mob-search-backdrop" class="sm:hidden"></div>
   <div id="mob-search" class="sm:hidden" aria-modal="true" role="search" aria-label="Search">
     <div id="mob-search-scroll">
-      <div style="padding: 12px 16px 8px; display:flex; align-items:center; gap:10px;">
-        <button class="mob-gbtn" id="mob-search-back" aria-label="Close search">
-          <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><polyline points="15 18 9 12 15 6"/></svg>
+      <div style="width:38px;height:5px;border-radius:9px;background:#dadfdb;margin:10px auto 4px;flex-shrink:0;"></div>
+      <div style="padding:8px 16px 8px;display:flex;align-items:center;gap:10px;flex-shrink:0;">
+        <h2 style="font-family:var(--mob-serif);font-weight:700;font-size:26px;color:var(--mob-ink);margin:0;flex:1;">Search</h2>
+        <button class="mob-gbtn" id="mob-search-back" aria-label="Close" style="background:var(--mob-bg);">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
         </button>
-        <h2 style="font-family:var(--mob-serif);font-weight:700;font-size:28px;color:var(--mob-ink);margin:0;">Search</h2>
       </div>
-      <div style="padding: 6px 16px 10px;">
-        <div style="display:flex;align-items:center;gap:9px;background:#fff;border:1px solid var(--mob-line);border-radius:13px;padding:0 12px;height:44px;">
+      <div style="padding:0 16px 10px;flex-shrink:0;">
+        <div style="display:flex;align-items:center;gap:9px;background:var(--mob-bg);border:1px solid var(--mob-line);border-radius:13px;padding:0 12px;height:44px;">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#9aa39c" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
           <input id="mob-search-input" type="search" autocomplete="off"
-            placeholder="Genes, locus tags, products…"
+            placeholder="Genes, locus tags, mutants…"
             style="border:none;outline:none;flex:1;font-family:var(--mob-sans);font-size:15px;background:transparent;color:var(--mob-ink);" />
         </div>
       </div>
-      <div id="mob-search-results"></div>
+      <div id="mob-search-results" style="flex:1;overflow-y:auto;-webkit-overflow-scrolling:touch;min-height:120px;"></div>
     </div>
   </div>
 

--- a/web/index.html
+++ b/web/index.html
@@ -419,6 +419,6 @@
   <!-- Supabase JS client (ESM via CDN) -->
   <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.min.js"></script>
   <script src="/web/js/chlam-globe-bg.js"></script>
-  <script type="module" src="/web/js/app.js?v=91"></script>
+  <script type="module" src="/web/js/app.js?v=92"></script>
 </body>
 </html>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -233,6 +233,9 @@ function initMobileShell() {
     });
   };
 
+  // Apply active state for the tab that was already activated before this hook was registered
+  window.__activateTabHook(state.currentTab);
+
   updateMobPipelineVisibility();
 }
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1,7 +1,7 @@
 // ChlamAtlas — main application entry point
 import { sb, state, SUPABASE_URL, SUPABASE_ANON_KEY, syncFavoritesFromDB } from './client.js?v=82';
-import { renderHome } from './views/home.js?v=81';
-import { renderGenomes } from './views/genomes.js?v=93';
+import { renderHome } from './views/home.js?v=82';
+import { renderGenomes } from './views/genomes.js?v=95';
 import { renderMutants } from './views/mutants.js?v=96';
 import { renderPipeline } from './views/pipeline.js?v=82';
 import { renderRoadmap }  from './views/roadmap.js?v=91';

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -12,6 +12,273 @@ import { renderBugs } from './views/bugs.js?v=1';
 
 export { sb, state };
 
+// ─── Mobile viewport detection ─────────────────────────────
+export function isMobileViewport() {
+  return window.innerWidth < 640;
+}
+
+// ─── Mobile push/pop detail overlay ────────────────────────
+let _mobDetailStack = [];
+let _mobDetailDrag  = { active: false, x0: 0, dx: 0 };
+
+export function pushMobileDetail({ render, title = '' }) {
+  const overlay = document.getElementById('mob-detail');
+  const scroll  = document.getElementById('mob-detail-scroll');
+  if (!overlay || !scroll) return;
+
+  _mobDetailStack.push({ title });
+  scroll.innerHTML = '';
+  render(scroll);
+
+  _setMobNavTitle(title);
+  _showMobBack(true);
+
+  overlay.style.transition = 'none';
+  overlay.style.transform   = 'translateX(100%)';
+  requestAnimationFrame(() => {
+    overlay.style.transition = 'transform .34s cubic-bezier(.32,.72,0,1)';
+    overlay.style.transform   = 'translateX(0)';
+    overlay.classList.add('open');
+  });
+
+  scroll.onscroll = () => {
+    const show = scroll.scrollTop > 26;
+    document.getElementById('mob-bar')?.classList.toggle('show', show);
+  };
+
+  overlay.removeEventListener('touchstart', _mobSwipeStart);
+  overlay.removeEventListener('touchmove',  _mobSwipeMove);
+  overlay.removeEventListener('touchend',   _mobSwipeEnd);
+  overlay.addEventListener('touchstart', _mobSwipeStart, { passive: true });
+  overlay.addEventListener('touchmove',  _mobSwipeMove,  { passive: true });
+  overlay.addEventListener('touchend',   _mobSwipeEnd,   { passive: false });
+}
+
+export function popMobileDetail() {
+  const overlay = document.getElementById('mob-detail');
+  if (!overlay) return;
+
+  overlay.style.transition = 'transform .3s cubic-bezier(.4,0,.6,1)';
+  overlay.style.transform   = 'translateX(100%)';
+
+  _mobDetailStack.pop();
+  const prev     = _mobDetailStack[_mobDetailStack.length - 1];
+  const hasDetail = _mobDetailStack.length > 0;
+
+  setTimeout(() => {
+    overlay.classList.remove('open');
+    const s = document.getElementById('mob-detail-scroll');
+    if (s) s.innerHTML = '';
+    overlay.removeEventListener('touchstart', _mobSwipeStart);
+    overlay.removeEventListener('touchmove',  _mobSwipeMove);
+    overlay.removeEventListener('touchend',   _mobSwipeEnd);
+
+    _showMobBack(hasDetail);
+    _setMobNavTitle(hasDetail && prev ? prev.title : _currentTabTitle());
+    document.getElementById('mob-bar')?.classList.remove('show');
+  }, 290);
+}
+
+function _mobSwipeStart(e) {
+  const x = e.touches[0].clientX;
+  if (x > 40) return;
+  _mobDetailDrag = { active: true, x0: x, dx: 0 };
+  const overlay = document.getElementById('mob-detail');
+  if (overlay) overlay.style.transition = 'none';
+}
+function _mobSwipeMove(e) {
+  if (!_mobDetailDrag.active) return;
+  const dx = Math.max(0, e.touches[0].clientX - _mobDetailDrag.x0);
+  _mobDetailDrag.dx = dx;
+  const overlay = document.getElementById('mob-detail');
+  if (overlay) overlay.style.transform = `translateX(${dx}px)`;
+}
+function _mobSwipeEnd() {
+  if (!_mobDetailDrag.active) return;
+  _mobDetailDrag.active = false;
+  if (_mobDetailDrag.dx > 90) {
+    popMobileDetail();
+  } else {
+    const overlay = document.getElementById('mob-detail');
+    if (overlay) {
+      overlay.style.transition = 'transform .25s ease';
+      overlay.style.transform   = 'translateX(0)';
+    }
+  }
+}
+
+// ─── Mobile search overlay ──────────────────────────────────
+export function pushMobileSearch() {
+  const overlay = document.getElementById('mob-search');
+  if (!overlay) return;
+  overlay.style.transition = 'none';
+  overlay.style.transform   = 'translateX(100%)';
+  requestAnimationFrame(() => {
+    overlay.style.transition = 'transform .34s cubic-bezier(.32,.72,0,1)';
+    overlay.style.transform   = 'translateX(0)';
+    overlay.classList.add('open');
+  });
+  setTimeout(() => document.getElementById('mob-search-input')?.focus(), 350);
+  _showMobBack(false);
+}
+
+export function popMobileSearch() {
+  const overlay = document.getElementById('mob-search');
+  if (!overlay) return;
+  overlay.style.transition = 'transform .3s cubic-bezier(.4,0,.6,1)';
+  overlay.style.transform   = 'translateX(100%)';
+  setTimeout(() => {
+    overlay.classList.remove('open');
+    const inp = document.getElementById('mob-search-input');
+    const res = document.getElementById('mob-search-results');
+    if (inp) inp.value = '';
+    if (res) res.innerHTML = '';
+  }, 290);
+}
+
+// ─── Collapsing nav bar ─────────────────────────────────────
+const _TAB_TITLES = {
+  home: 'ChlamAtlas', genomes: 'Genomes', mutants: 'Mutants',
+  pipeline: 'Pipeline', tools: 'Tools',
+};
+
+function _currentTabTitle() {
+  return _TAB_TITLES[state.currentTab] ?? 'ChlamAtlas';
+}
+
+function _setMobNavTitle(title) {
+  const el = document.getElementById('mob-bar-title');
+  if (el) el.textContent = title;
+}
+
+function _showMobBack(show) {
+  const left = document.getElementById('mob-nav-left');
+  if (!left) return;
+  if (show) {
+    left.innerHTML = `
+      <button class="mob-gbtn" id="mob-back-btn" aria-label="Back">
+        <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><polyline points="15 18 9 12 15 6"/></svg>
+      </button>`;
+    document.getElementById('mob-back-btn').addEventListener('click', popMobileDetail);
+  } else {
+    left.innerHTML = '';
+  }
+}
+
+export function onMobScroll(scrollEl, threshold, title) {
+  scrollEl.addEventListener('scroll', () => {
+    const show = scrollEl.scrollTop > threshold;
+    document.getElementById('mob-bar')?.classList.toggle('show', show);
+  }, { passive: true });
+  _setMobNavTitle(title);
+}
+
+// ─── Mobile shell initializer ────────────────────────────────
+function updateMobPipelineVisibility() {
+  const tab = document.getElementById('mob-tab-pipeline');
+  if (!tab) return;
+  tab.style.display = ['lab_member', 'admin'].includes(state.userRole) ? '' : 'none';
+}
+
+function initMobileShell() {
+  if (!isMobileViewport()) return;
+
+  document.getElementById('mob-btn-search')?.addEventListener('click', pushMobileSearch);
+  document.getElementById('mob-search-back')?.addEventListener('click', popMobileSearch);
+
+  const searchInput   = document.getElementById('mob-search-input');
+  const searchResults = document.getElementById('mob-search-results');
+  if (searchInput && searchResults) {
+    searchInput.addEventListener('input', () => {
+      const q = searchInput.value.trim().toLowerCase();
+      if (!q) { searchResults.innerHTML = ''; return; }
+      _renderMobSearchResults(q, searchResults);
+    });
+  }
+
+  document.getElementById('mob-btn-saved')?.addEventListener('click', (e) => {
+    showSavedPopover(e.currentTarget);
+  });
+
+  document.getElementById('mob-btn-account')?.addEventListener('click', (e) => {
+    e.stopPropagation();
+    if (state.user) toggleUserDropdown();
+    else showAuthModal('signin');
+  });
+
+  document.querySelectorAll('.mob-tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const tab = btn.dataset.tab;
+      if (!tab) return;
+
+      if (_mobDetailStack.length > 0) {
+        const overlay = document.getElementById('mob-detail');
+        if (overlay) {
+          overlay.classList.remove('open');
+          overlay.style.transform = 'translateX(100%)';
+        }
+        _mobDetailStack = [];
+        _showMobBack(false);
+      }
+
+      activateTab(tab);
+      document.getElementById('mob-bar')?.classList.remove('show');
+      _setMobNavTitle(_TAB_TITLES[tab] ?? tab);
+    });
+  });
+
+  window.__activateTabHook = (name) => {
+    document.querySelectorAll('.mob-tab-btn').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.tab === name);
+    });
+  };
+
+  updateMobPipelineVisibility();
+}
+
+async function _renderMobSearchResults(q, container) {
+  const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  container.innerHTML = '<div style="padding:12px 20px;font-size:13px;color:var(--mob-ink-3)">Searching…</div>';
+  const { data } = await sb
+    .from('genes')
+    .select('id,locus_tag,gene_name,gene_symbol,functional_category,proteins(alphafold_results(thumbnail_path))')
+    .or(`locus_tag.ilike.%${q}%,gene_name.ilike.%${q}%,gene_symbol.ilike.%${q}%,product.ilike.%${q}%`)
+    .limit(30);
+
+  if (!data || data.length === 0) {
+    const safeQ = q.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+    container.innerHTML = `<div style="padding:20px;text-align:center;color:var(--mob-ink-3);font-size:14px;">No results for "${safeQ}"</div>`;
+    return;
+  }
+
+  const rows = data.map(g => {
+    const thumb = g.proteins?.alphafold_results?.find(r => r.thumbnail_path)?.thumbnail_path;
+    return `
+      <div class="mob-grow" data-mob-search-gene="${g.id}">
+        <div class="mob-bar" style="background:#2f9e6e;"></div>
+        <div class="mob-thumb mob-stile">
+          ${thumb ? `<img src="${thumb}" alt="">` : '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#ccc" stroke-width="1.5"><circle cx="12" cy="12" r="8"/></svg>'}
+        </div>
+        <div class="mob-meta">
+          <div class="mob-gname">${esc(g.gene_name || g.gene_symbol || g.locus_tag)}<span class="mob-loc">${g.gene_name ? esc(g.locus_tag) : ''}</span></div>
+          <div class="mob-gfunc">${esc(g.functional_category ?? '')}</div>
+        </div>
+        <span class="mob-chev"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><polyline points="9 18 15 12 9 6"/></svg></span>
+        <div class="mob-sep"></div>
+      </div>`;
+  }).join('');
+
+  container.innerHTML = `<div style="background:#fff;">${rows}</div>`;
+
+  container.querySelectorAll('[data-mob-search-gene]').forEach(row => {
+    row.addEventListener('click', () => {
+      popMobileSearch();
+      window.__openGeneId = row.dataset.mobSearchGene;
+      activateTab('genomes');
+    });
+  });
+}
+
 // ─── Nav stub buttons ──────────────────────────────────────
 function wireNavStubs() {
   document.getElementById('btn-nav-search')?.addEventListener('click', (e) => {
@@ -107,6 +374,7 @@ function activateTab(name) {
   }
 
   history.replaceState(null, '', `#/${name}`);
+  window.__activateTabHook?.(name);
 }
 
 // Used by the Pipeline tab to navigate directly to a specific mutant record,
@@ -656,6 +924,7 @@ function updateNavVisibility() {
   document.querySelectorAll('[data-tab="pipeline"]').forEach(btn => {
     btn.style.display = showPipeline ? '' : 'none';
   });
+  updateMobPipelineVisibility();
 }
 
 // ─── Auth modal ────────────────────────────────────────────
@@ -1226,3 +1495,4 @@ updateNavVisibility();
 wireNavStubs();
 const _hash = location.hash.replace(/^#\/?/, '');
 activateTab(TABS.includes(_hash) ? _hash : 'home');
+initMobileShell();

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1,7 +1,7 @@
 // ChlamAtlas — main application entry point
 import { sb, state, SUPABASE_URL, SUPABASE_ANON_KEY, syncFavoritesFromDB } from './client.js?v=82';
 import { renderHome } from './views/home.js?v=82';
-import { renderGenomes } from './views/genomes.js?v=96';
+import { renderGenomes } from './views/genomes.js?v=97';
 import { renderMutants } from './views/mutants.js?v=96';
 import { renderPipeline } from './views/pipeline.js?v=82';
 import { renderRoadmap }  from './views/roadmap.js?v=91';

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1,8 +1,8 @@
 // ChlamAtlas — main application entry point
 import { sb, state, SUPABASE_URL, SUPABASE_ANON_KEY, syncFavoritesFromDB } from './client.js?v=82';
 import { renderHome } from './views/home.js?v=81';
-import { renderGenomes } from './views/genomes.js?v=91';
-import { renderMutants } from './views/mutants.js?v=95';
+import { renderGenomes } from './views/genomes.js?v=92';
+import { renderMutants } from './views/mutants.js?v=96';
 import { renderPipeline } from './views/pipeline.js?v=82';
 import { renderRoadmap }  from './views/roadmap.js?v=91';
 import { renderAlignment } from './views/alignment.js?v=97';

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -202,8 +202,14 @@ function initMobileShell() {
 
   document.getElementById('mob-btn-account')?.addEventListener('click', (e) => {
     e.stopPropagation();
-    if (state.user) toggleUserDropdown();
-    else showAuthModal('signin');
+    if (!state.user) { showAuthModal('signin'); return; }
+    toggleUserDropdown();
+    // Reposition dropdown to the mobile button's actual screen location
+    if (_dropdownEl) {
+      const rect = e.currentTarget.getBoundingClientRect();
+      _dropdownEl.style.top   = (rect.bottom + 6) + 'px';
+      _dropdownEl.style.right = (window.innerWidth - rect.right) + 'px';
+    }
   });
 
   document.querySelectorAll('.mob-tab-btn').forEach(btn => {
@@ -241,43 +247,84 @@ function initMobileShell() {
 
 async function _renderMobSearchResults(q, container) {
   const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
-  container.innerHTML = '<div style="padding:12px 20px;font-size:13px;color:var(--mob-ink-3)">Searching…</div>';
-  const { data } = await sb
-    .from('genes')
-    .select('id,locus_tag,gene_name,gene_symbol,functional_category,proteins(alphafold_results(thumbnail_path))')
-    .or(`locus_tag.ilike.%${q}%,gene_name.ilike.%${q}%,gene_symbol.ilike.%${q}%,product.ilike.%${q}%`)
-    .limit(30);
+  const safeQ = esc(q);
+  const chev = `<span class="mob-chev"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><polyline points="9 18 15 12 9 6"/></svg></span>`;
 
-  if (!data || data.length === 0) {
-    const safeQ = q.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  container.innerHTML = '<div style="padding:12px 20px;font-size:13px;color:var(--mob-ink-3)">Searching…</div>';
+
+  const [geneRes, mutRes] = await Promise.all([
+    sb.from('genes')
+      .select('id,locus_tag,gene_name,gene_symbol,functional_category,proteins(alphafold_results(thumbnail_path))')
+      .or(`locus_tag.ilike.%${q}%,gene_name.ilike.%${q}%,gene_symbol.ilike.%${q}%,product.ilike.%${q}%`)
+      .limit(20),
+    sb.from('mutants')
+      .select('id,mutant_id,name,mutation_type,collection')
+      .or(`mutant_id.ilike.%${q}%,name.ilike.%${q}%`)
+      .limit(10),
+  ]);
+
+  const genes   = geneRes.data   ?? [];
+  const mutants = mutRes.data    ?? [];
+
+  if (!genes.length && !mutants.length) {
     container.innerHTML = `<div style="padding:20px;text-align:center;color:var(--mob-ink-3);font-size:14px;">No results for "${safeQ}"</div>`;
     return;
   }
 
-  const rows = data.map(g => {
+  const MOB_TYPE_COLORS = { deletion:'#C0392B', transposon:'#059669', chimera:'#8466C4', chemical:'#2563eb', intron:'#ca8a04', recombination:'#8466C4' };
+
+  const geneRows = genes.map((g, i) => {
     const thumb = g.proteins?.alphafold_results?.find(r => r.thumbnail_path)?.thumbnail_path;
     return `
       <div class="mob-grow" data-mob-search-gene="${g.id}">
         <div class="mob-bar" style="background:#2f9e6e;"></div>
         <div class="mob-thumb mob-stile">
-          ${thumb ? `<img src="${thumb}" alt="">` : '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#ccc" stroke-width="1.5"><circle cx="12" cy="12" r="8"/></svg>'}
+          ${thumb ? `<img src="${esc(thumb)}" alt="">` : '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#ccc" stroke-width="1.5"><circle cx="12" cy="12" r="8"/></svg>'}
         </div>
         <div class="mob-meta">
           <div class="mob-gname">${esc(g.gene_name || g.gene_symbol || g.locus_tag)}<span class="mob-loc">${g.gene_name ? esc(g.locus_tag) : ''}</span></div>
           <div class="mob-gfunc">${esc(g.functional_category ?? '')}</div>
         </div>
-        <span class="mob-chev"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><polyline points="9 18 15 12 9 6"/></svg></span>
-        <div class="mob-sep"></div>
+        ${chev}
+        ${i < genes.length - 1 ? '<div class="mob-sep"></div>' : ''}
       </div>`;
   }).join('');
 
-  container.innerHTML = `<div style="background:#fff;">${rows}</div>`;
+  const mutRows = mutants.map((m, i) => {
+    const col = MOB_TYPE_COLORS[m.mutation_type] ?? '#8b958f';
+    return `
+      <div class="mob-grow" data-mob-search-mut="${m.id}">
+        <div class="mob-bar" style="background:${col};"></div>
+        <div class="mob-thumb mob-stile" style="background:${col}14;box-shadow:inset 0 0 0 1px ${col}33;display:grid;place-items:center;font-family:var(--mob-mono);font-weight:600;font-size:16px;color:${col};">
+          ${m.mutation_type === 'deletion' ? 'Δ' : m.mutation_type === 'chimera' || m.mutation_type === 'recombination' ? '×' : '::'}
+        </div>
+        <div class="mob-meta">
+          <div class="mob-gname" style="font-family:var(--mob-mono);font-weight:600;">${esc(m.name || m.mutant_id)}</div>
+          <div class="mob-gfunc">${esc(m.collection ?? '')} · ${esc(m.mutation_type ?? '')}</div>
+        </div>
+        ${chev}
+        ${i < mutants.length - 1 ? '<div class="mob-sep"></div>' : ''}
+      </div>`;
+  }).join('');
+
+  const secH = (label, n) => `<div class="mob-section-h" style="position:static;">${label} <span class="mob-sh-count">· ${n}</span></div>`;
+
+  container.innerHTML = `<div style="background:#fff;">
+    ${genes.length   ? secH('Genes',   genes.length)   + geneRows   : ''}
+    ${mutants.length ? secH('Mutants', mutants.length) + mutRows    : ''}
+  </div>`;
 
   container.querySelectorAll('[data-mob-search-gene]').forEach(row => {
     row.addEventListener('click', () => {
       popMobileSearch();
       window.__openGeneId = row.dataset.mobSearchGene;
       activateTab('genomes');
+    });
+  });
+  container.querySelectorAll('[data-mob-search-mut]').forEach(row => {
+    row.addEventListener('click', () => {
+      popMobileSearch();
+      _mobLoadMutantDetail(row.dataset.mobSearchMut);
     });
   });
 }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1,7 +1,7 @@
 // ChlamAtlas — main application entry point
 import { sb, state, SUPABASE_URL, SUPABASE_ANON_KEY, syncFavoritesFromDB } from './client.js?v=82';
 import { renderHome } from './views/home.js?v=81';
-import { renderGenomes } from './views/genomes.js?v=92';
+import { renderGenomes } from './views/genomes.js?v=93';
 import { renderMutants } from './views/mutants.js?v=96';
 import { renderPipeline } from './views/pipeline.js?v=82';
 import { renderRoadmap }  from './views/roadmap.js?v=91';

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -200,19 +200,9 @@ function initMobileShell() {
     showSavedPopover(e.currentTarget);
   });
 
-  document.getElementById('mob-btn-account')?.addEventListener('click', (e) => {
-    e.stopPropagation();
+  document.getElementById('mob-btn-account')?.addEventListener('click', () => {
     if (!state.user) { showAuthModal('signin'); return; }
-    toggleUserDropdown();
-    // Reposition dropdown to the mobile button's actual screen location
-    if (_dropdownEl) {
-      const rect = e.currentTarget.getBoundingClientRect();
-      _dropdownEl.style.top       = (rect.bottom + 6) + 'px';
-      _dropdownEl.style.right     = '10px';
-      _dropdownEl.style.minWidth  = '220px';
-      _dropdownEl.style.maxHeight = (window.innerHeight - rect.bottom - 20) + 'px';
-      _dropdownEl.style.overflowY = 'auto';
-    }
+    _showMobAccountSheet();
   });
 
   document.querySelectorAll('.mob-tab-btn').forEach(btn => {
@@ -266,6 +256,82 @@ function initMobileShell() {
   window.__activateTabHook(state.currentTab);
 
   updateMobPipelineVisibility();
+}
+
+// ─── Mobile account bottom sheet ────────────────────────────
+function _showMobAccountSheet() {
+  document.getElementById('mob-account-sheet')?.remove();
+
+  const profile  = state.userProfile;
+  const name     = profile?.display_name || (state.user?.email ?? '').split('@')[0];
+  const email    = state.user?.email ?? '';
+  const role     = state.userRole;
+  const roleLabels = { admin: 'Admin', lab_member: 'Lab member', community: 'Community' };
+  const roleColors = { admin: '#163b2b', lab_member: '#1d6f4a', community: '#6b7280' };
+
+  const initial  = name.charAt(0).toUpperCase();
+  const isAdmin  = role === 'admin';
+  const isCom    = role === 'community';
+  const hasRequest = profile?.role_request;
+
+  const backdrop = document.createElement('div');
+  backdrop.id = 'mob-account-sheet';
+  backdrop.className = 'mob-sheet-backdrop';
+
+  const rowStyle = `display:flex;align-items:center;gap:13px;padding:13px 4px;border-top:.5px solid #f0f0f0;cursor:pointer;font-size:14.5px;font-weight:600;color:#18221c;`;
+
+  backdrop.innerHTML = `
+    <div class="mob-sheet" onclick="event.stopPropagation()" style="padding-bottom:calc(env(safe-area-inset-bottom,14px)+12px);">
+      <div class="mob-sheet-handle"></div>
+      <!-- Identity header -->
+      <div style="display:flex;align-items:center;gap:12px;padding:4px 4px 14px;">
+        <div style="width:42px;height:42px;border-radius:50%;background:#163b2b;color:#fff;display:grid;place-items:center;font-size:18px;font-weight:700;flex-shrink:0;">${initial}</div>
+        <div style="min-width:0;flex:1;">
+          <div style="font-weight:700;font-size:15.5px;color:#18221c;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${name}</div>
+          <div style="font-size:11.5px;color:#8b958f;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${email}</div>
+          <span style="display:inline-block;margin-top:4px;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;color:#fff;background:${roleColors[role]??'#6b7280'};border-radius:4px;padding:2px 7px;">${roleLabels[role]??role}</span>
+        </div>
+      </div>
+      <!-- Menu rows -->
+      <div id="mob-acct-my-account" style="${rowStyle}">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg>
+        My account
+      </div>
+      ${isCom && !hasRequest ? `<div id="mob-acct-request" style="${rowStyle}">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><circle cx="8" cy="15" r="5"/><path d="M21 3l-9.4 9.4M17 3h4v4"/></svg>
+        Request lab access
+      </div>` : isCom && hasRequest ? `<div style="padding:11px 4px;border-top:.5px solid #f0f0f0;font-size:13px;color:#9ca3af;font-style:italic;">Lab access request pending</div>` : ''}
+      ${isAdmin ? `<div id="mob-acct-admin" style="${rowStyle}">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><circle cx="9" cy="8" r="3.5"/><path d="M2 20c0-3.5 3.1-6 7-6s7 2.5 7 6"/><circle cx="18" cy="8" r="2.5"/><path d="M22 20c0-2.5-2-4.5-4-5"/></svg>
+        Manage users
+      </div>` : ''}
+      <div id="mob-acct-whats-new" style="${rowStyle}">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+        What's new
+      </div>
+      <div id="mob-acct-bugs" style="${rowStyle}">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M8 2l1.5 1.5M16 2l-1.5 1.5M12 8a4 4 0 0 0-4 4v3a4 4 0 0 0 8 0v-3a4 4 0 0 0-4-4z"/><path d="M8 12H4M20 12h-4M8 16H5M19 16h-3"/></svg>
+        Bug reports
+      </div>
+      <div id="mob-acct-signout" style="${rowStyle}color:#c0392b;">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+        Sign out
+      </div>
+    </div>`;
+
+  const close = () => backdrop.remove();
+  backdrop.addEventListener('click', close);
+
+  const wire = (id, fn) => backdrop.querySelector('#' + id)?.addEventListener('click', (e) => { e.stopPropagation(); close(); fn(); });
+
+  wire('mob-acct-my-account', () => showAccountModal());
+  wire('mob-acct-request',    () => requestLabAccess?.());
+  wire('mob-acct-admin',      () => showAdminPanel?.());
+  wire('mob-acct-whats-new',  () => activateTab('roadmap'));
+  wire('mob-acct-bugs',       () => activateTab('bugs'));
+  wire('mob-acct-signout',    () => signOut());
+
+  document.body.appendChild(backdrop);
 }
 
 async function _renderMobSearchResults(q, container) {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -207,8 +207,11 @@ function initMobileShell() {
     // Reposition dropdown to the mobile button's actual screen location
     if (_dropdownEl) {
       const rect = e.currentTarget.getBoundingClientRect();
-      _dropdownEl.style.top   = (rect.bottom + 6) + 'px';
-      _dropdownEl.style.right = (window.innerWidth - rect.right) + 'px';
+      _dropdownEl.style.top       = (rect.bottom + 6) + 'px';
+      _dropdownEl.style.right     = '10px';
+      _dropdownEl.style.minWidth  = '220px';
+      _dropdownEl.style.maxHeight = (window.innerHeight - rect.bottom - 20) + 'px';
+      _dropdownEl.style.overflowY = 'auto';
     }
   });
 
@@ -233,10 +236,30 @@ function initMobileShell() {
     });
   });
 
+  const _MOB_NAV_TABS = new Set(['home','genomes','mutants','pipeline','tools']);
+
   window.__activateTabHook = (name) => {
+    // Sync mob-tab-btn active states
     document.querySelectorAll('.mob-tab-btn').forEach(btn => {
       btn.classList.toggle('active', btn.dataset.tab === name);
     });
+
+    const left = document.getElementById('mob-nav-left');
+    if (!left) return;
+
+    if (!_MOB_NAV_TABS.has(name) && !_mobDetailStack.length) {
+      // Tab has no mobile nav button (roadmap, bugs, alignment, etc.)
+      // Show a back-to-home button so the user isn't stranded
+      left.innerHTML = `
+        <button class="mob-gbtn" id="mob-back-btn" aria-label="Back">
+          <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><polyline points="15 18 9 12 15 6"/></svg>
+        </button>`;
+      document.getElementById('mob-back-btn').addEventListener('click', () => {
+        activateTab('home');
+      });
+    } else if (_MOB_NAV_TABS.has(name) && !_mobDetailStack.length) {
+      left.innerHTML = '';
+    }
   };
 
   // Apply active state for the tab that was already activated before this hook was registered

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1,7 +1,7 @@
 // ChlamAtlas — main application entry point
 import { sb, state, SUPABASE_URL, SUPABASE_ANON_KEY, syncFavoritesFromDB } from './client.js?v=82';
 import { renderHome } from './views/home.js?v=82';
-import { renderGenomes } from './views/genomes.js?v=95';
+import { renderGenomes } from './views/genomes.js?v=96';
 import { renderMutants } from './views/mutants.js?v=96';
 import { renderPipeline } from './views/pipeline.js?v=82';
 import { renderRoadmap }  from './views/roadmap.js?v=91';

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1,7 +1,7 @@
 // ChlamAtlas — main application entry point
 import { sb, state, SUPABASE_URL, SUPABASE_ANON_KEY, syncFavoritesFromDB } from './client.js?v=82';
 import { renderHome } from './views/home.js?v=82';
-import { renderGenomes } from './views/genomes.js?v=98';
+import { renderGenomes } from './views/genomes.js?v=100';
 import { renderMutants } from './views/mutants.js?v=96';
 import { renderPipeline } from './views/pipeline.js?v=82';
 import { renderRoadmap }  from './views/roadmap.js?v=91';

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1,7 +1,7 @@
 // ChlamAtlas — main application entry point
 import { sb, state, SUPABASE_URL, SUPABASE_ANON_KEY, syncFavoritesFromDB } from './client.js?v=82';
 import { renderHome } from './views/home.js?v=82';
-import { renderGenomes } from './views/genomes.js?v=97';
+import { renderGenomes } from './views/genomes.js?v=98';
 import { renderMutants } from './views/mutants.js?v=96';
 import { renderPipeline } from './views/pipeline.js?v=82';
 import { renderRoadmap }  from './views/roadmap.js?v=91';

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -193,6 +193,9 @@ export async function pushMobileSaved() {
         <svg width="18" height="18" viewBox="0 0 24 24" fill="#e8b400" stroke="#e8b400" stroke-width="1.5"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
         <span style="font-weight:800;font-size:17px;color:var(--mob-ink);">Saved</span>
         <span style="color:var(--mob-ink-3);font-size:13px;font-weight:600;">· ${genes.length + mutants.length}</span>
+        <button id="mob-saved-close" style="margin-left:auto;width:30px;height:30px;border-radius:50%;border:none;background:#f0f2f0;display:grid;place-items:center;cursor:pointer;">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+        </button>
       </div>
       ${genes.length || mutants.length
         ? (genes.length   ? secH('Genes',   genes.length)   + `<div style="background:var(--mob-paper);">${gRows}</div>` : '')
@@ -201,6 +204,7 @@ export async function pushMobileSaved() {
     </div>`;
 
   backdrop.addEventListener('click', () => backdrop.remove());
+  backdrop.querySelector('#mob-saved-close')?.addEventListener('click', (e) => { e.stopPropagation(); backdrop.remove(); });
   backdrop.querySelectorAll('[data-saved-gene]').forEach(row => {
     row.addEventListener('click', () => { backdrop.remove(); window.__openGeneId = row.dataset.savedGene; activateTab('genomes'); });
   });
@@ -284,6 +288,8 @@ function initMobileShell() {
       const tab = btn.dataset.tab;
       if (!tab) return;
 
+      if (tab === 'tools') { _showMobToolsSheet(); return; }
+
       if (_mobDetailStack.length > 0) {
         const overlay = document.getElementById('mob-detail');
         if (overlay) {
@@ -332,6 +338,53 @@ function initMobileShell() {
   updateMobPipelineVisibility();
 }
 
+// ─── Mobile tools bottom sheet ───────────────────────────────
+function _showMobToolsSheet() {
+  document.getElementById('mob-tools-sheet')?.remove();
+
+  const rowStyle = `display:flex;align-items:center;gap:13px;padding:13px 4px;border-top:.5px solid #f0f0f0;cursor:pointer;font-size:14.5px;font-weight:600;color:#18221c;`;
+
+  const backdrop = document.createElement('div');
+  backdrop.id = 'mob-tools-sheet';
+  backdrop.className = 'mob-sheet-backdrop';
+  backdrop.innerHTML = `
+    <div class="mob-sheet" onclick="event.stopPropagation()" style="padding-bottom:calc(env(safe-area-inset-bottom,14px)+12px);">
+      <div class="mob-sheet-handle"></div>
+      <div style="display:flex;align-items:center;padding:4px 4px 12px;">
+        <span style="font-weight:800;font-size:17px;color:#18221c;flex:1;">Tools</span>
+        <button id="mob-tools-close" style="width:30px;height:30px;border-radius:50%;border:none;background:#f0f2f0;display:grid;place-items:center;cursor:pointer;">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+        </button>
+      </div>
+      <div id="mob-tools-genome-align" style="${rowStyle}">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v16a2 2 0 0 0 2 2h16"/><path d="M7 16h8"/><path d="M7 11h12"/><path d="M7 6h3"/></svg>
+        Genome Alignment
+      </div>
+      <div id="mob-tools-seq-align" style="${rowStyle}">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="m10 16 1.5 1.5"/><path d="m14 8-1.5-1.5"/><path d="M15 2c-1.798 1.998-2.518 3.995-2.807 5.993"/><path d="m16.5 10.5 1 1"/><path d="m17 6-2.891-2.891"/><path d="M2 15c6.667-6 13.333 0 20-6"/><path d="m20 9 .891.891"/><path d="M3.109 14.109 4 15"/><path d="m6.5 12.5 1 1"/><path d="m7 18 2.891 2.891"/><path d="M9 22c1.798-1.998 2.518-3.995 2.807-5.993"/></svg>
+        Sequence Alignment
+      </div>
+      <div id="mob-tools-struct-align" style="${rowStyle}">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.106-3.105c.32-.322.863-.22.983.218a6 6 0 0 1-8.259 7.057l-7.91 7.91a1 1 0 0 1-2.999-3l7.91-7.91a6 6 0 0 1 7.057-8.259c.438.12.54.662.219.984z"/></svg>
+        Structure Alignment
+      </div>
+    </div>`;
+
+  const close = () => backdrop.remove();
+  backdrop.addEventListener('click', close);
+
+  const wire = (id, tabName) => backdrop.querySelector('#' + id)?.addEventListener('click', (e) => {
+    e.stopPropagation(); close(); activateTab(tabName);
+  });
+
+  backdrop.querySelector('#mob-tools-close')?.addEventListener('click', (e) => { e.stopPropagation(); close(); });
+  wire('mob-tools-genome-align', 'genome-alignment');
+  wire('mob-tools-seq-align',    'alignment');
+  wire('mob-tools-struct-align', 'structure-alignment');
+
+  document.body.appendChild(backdrop);
+}
+
 // ─── Mobile account bottom sheet ────────────────────────────
 function _showMobAccountSheet() {
   document.getElementById('mob-account-sheet')?.remove();
@@ -365,10 +418,13 @@ function _showMobAccountSheet() {
           <div style="font-size:11.5px;color:#8b958f;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${email}</div>
           <span style="display:inline-block;margin-top:4px;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;color:#fff;background:${roleColors[role]??'#6b7280'};border-radius:4px;padding:2px 7px;">${roleLabels[role]??role}</span>
         </div>
+        <button id="mob-acct-close" style="width:30px;height:30px;border-radius:50%;border:none;background:#f0f2f0;display:grid;place-items:center;cursor:pointer;flex-shrink:0;">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+        </button>
       </div>
       <!-- Menu rows -->
       <div id="mob-acct-my-account" style="${rowStyle}">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M16 2v2"/><path d="M17.915 22a6 6 0 0 0-12 0"/><path d="M8 2v2"/><circle cx="12" cy="12" r="4"/><rect x="3" y="4" width="18" height="18" rx="2"/></svg>
         My account
       </div>
       ${isCom && !hasRequest ? `<div id="mob-acct-request" style="${rowStyle}">
@@ -376,15 +432,15 @@ function _showMobAccountSheet() {
         Request lab access
       </div>` : isCom && hasRequest ? `<div style="padding:11px 4px;border-top:.5px solid #f0f0f0;font-size:13px;color:#9ca3af;font-style:italic;">Lab access request pending</div>` : ''}
       ${isAdmin ? `<div id="mob-acct-admin" style="${rowStyle}">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><circle cx="9" cy="8" r="3.5"/><path d="M2 20c0-3.5 3.1-6 7-6s7 2.5 7 6"/><circle cx="18" cy="8" r="2.5"/><path d="M22 20c0-2.5-2-4.5-4-5"/></svg>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M18 21a8 8 0 0 0-16 0"/><circle cx="10" cy="8" r="5"/><path d="M22 20c0-3.37-2-6.5-4-8a5 5 0 0 0-.45-8.3"/></svg>
         Manage users
       </div>` : ''}
       <div id="mob-acct-whats-new" style="${rowStyle}">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5.8 11.3 2 22l10.7-3.79"/><path d="M4 3h.01"/><path d="M22 8h.01"/><path d="M15 2h.01"/><path d="M22 20h.01"/><path d="m22 2-2.24.75a2.9 2.9 0 0 0-1.96 3.12c.1.86-.57 1.63-1.45 1.63h-.38c-.86 0-1.6.6-1.76 1.44L14 10"/><path d="m22 13-.82-.33c-.86-.34-1.82.2-1.98 1.11c-.11.7-.72 1.22-1.43 1.22H17"/><path d="m11 2 .33.82c.34.86-.2 1.82-1.11 1.98C9.52 4.9 9 5.52 9 6.23V7"/><path d="M11 13c1.93 1.93 2.83 4.17 2 5-.83.83-3.07-.07-5-2-1.93-1.93-2.83-4.17-2-5 .83-.83 3.07.07 5 2Z"/></svg>
         What's new
       </div>
       <div id="mob-acct-bugs" style="${rowStyle}">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M8 2l1.5 1.5M16 2l-1.5 1.5M12 8a4 4 0 0 0-4 4v3a4 4 0 0 0 8 0v-3a4 4 0 0 0-4-4z"/><path d="M8 12H4M20 12h-4M8 16H5M19 16h-3"/></svg>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20v-9"/><path d="M14 7a4 4 0 0 1 4 4v3a6 6 0 0 1-12 0v-3a4 4 0 0 1 4-4z"/><path d="M14.12 3.88 16 2"/><path d="M21 21a4 4 0 0 0-3.81-4"/><path d="M21 5a4 4 0 0 1-3.55 3.97"/><path d="M22 13h-4"/><path d="M3 21a4 4 0 0 1 3.81-4"/><path d="M3 5a4 4 0 0 0 3.55 3.97"/><path d="M6 13H2"/><path d="m8 2 1.88 1.88"/><path d="M9 7.13V6a3 3 0 1 1 6 0v1.13"/></svg>
         Bug reports
       </div>
       <div id="mob-acct-signout" style="${rowStyle}color:#c0392b;">
@@ -398,6 +454,7 @@ function _showMobAccountSheet() {
 
   const wire = (id, fn) => backdrop.querySelector('#' + id)?.addEventListener('click', (e) => { e.stopPropagation(); close(); fn(); });
 
+  backdrop.querySelector('#mob-acct-close')?.addEventListener('click', (e) => { e.stopPropagation(); close(); });
   wire('mob-acct-my-account', () => showAccountModal());
   wire('mob-acct-request',    () => requestLabAccess?.());
   wire('mob-acct-admin',      () => showAdminPanel?.());

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -107,33 +107,107 @@ function _mobSwipeEnd() {
   }
 }
 
-// ─── Mobile search overlay ──────────────────────────────────
+// ─── Mobile search — bottom sheet ───────────────────────────
 export function pushMobileSearch() {
-  const overlay = document.getElementById('mob-search');
-  if (!overlay) return;
-  overlay.style.transition = 'none';
-  overlay.style.transform   = 'translateX(100%)';
+  const sheet    = document.getElementById('mob-search');
+  const backdrop = document.getElementById('mob-search-backdrop');
+  if (!sheet) return;
+  sheet.style.transition = 'none';
+  sheet.style.transform   = 'translateY(100%)';
   requestAnimationFrame(() => {
-    overlay.style.transition = 'transform .34s cubic-bezier(.32,.72,0,1)';
-    overlay.style.transform   = 'translateX(0)';
-    overlay.classList.add('open');
+    sheet.style.transition = 'transform .34s cubic-bezier(.32,.72,0,1)';
+    sheet.style.transform   = 'translateY(0)';
+    sheet.classList.add('open');
+    backdrop?.classList.add('open');
   });
   setTimeout(() => document.getElementById('mob-search-input')?.focus(), 350);
-  _showMobBack(false);
+  backdrop?.addEventListener('click', popMobileSearch, { once: true });
 }
 
 export function popMobileSearch() {
-  const overlay = document.getElementById('mob-search');
-  if (!overlay) return;
-  overlay.style.transition = 'transform .3s cubic-bezier(.4,0,.6,1)';
-  overlay.style.transform   = 'translateX(100%)';
+  const sheet    = document.getElementById('mob-search');
+  const backdrop = document.getElementById('mob-search-backdrop');
+  if (!sheet) return;
+  sheet.style.transition = 'transform .3s cubic-bezier(.4,0,.6,1)';
+  sheet.style.transform   = 'translateY(100%)';
+  backdrop?.classList.remove('open');
   setTimeout(() => {
-    overlay.classList.remove('open');
+    sheet.classList.remove('open');
     const inp = document.getElementById('mob-search-input');
     const res = document.getElementById('mob-search-results');
     if (inp) inp.value = '';
     if (res) res.innerHTML = '';
   }, 290);
+}
+
+// ─── Mobile saved — bottom sheet ────────────────────────────
+export async function pushMobileSaved() {
+  document.getElementById('mob-saved-sheet')?.remove();
+
+  const geneIds   = [...state.favorites.genes];
+  const mutantIds = [...state.favorites.mutants];
+  const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  const chev = `<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><polyline points="9 18 15 12 9 6"/></svg>`;
+  const MOB_TYPE_COLORS = { deletion:'#C0392B', transposon:'#059669', chimera:'#8466C4', chemical:'#2563eb', intron:'#ca8a04', recombination:'#8466C4' };
+
+  const [genesRes, mutantsRes] = await Promise.all([
+    geneIds.length   ? sb.from('genes').select('id,locus_tag,gene_name,functional_category,proteins(alphafold_results(thumbnail_path))').in('id', geneIds)       : Promise.resolve({ data: [] }),
+    mutantIds.length ? sb.from('mutants').select('id,mutant_id,name,collection,mutation_type').in('id', mutantIds) : Promise.resolve({ data: [] }),
+  ]);
+
+  const genes   = genesRes.data   ?? [];
+  const mutants = mutantsRes.data ?? [];
+
+  const secH = (label, n) => `<div class="mob-section-h" style="position:static;background:var(--mob-paper);">${esc(label)} <span class="mob-sh-count">· ${n}</span></div>`;
+
+  const gRows = genes.map((g, i) => {
+    const thumb = g.proteins?.alphafold_results?.find(r => r.thumbnail_path)?.thumbnail_path;
+    return `<div class="mob-grow" data-saved-gene="${g.id}" style="background:var(--mob-paper);">
+      <div class="mob-bar" style="background:#2f9e6e;"></div>
+      <div class="mob-thumb mob-stile">${thumb ? `<img src="${esc(thumb)}" alt="">` : '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#ccc" stroke-width="1.5"><circle cx="12" cy="12" r="8"/></svg>'}</div>
+      <div class="mob-meta"><div class="mob-gname">${esc(g.gene_name || g.locus_tag)}<span class="mob-loc">${g.gene_name ? esc(g.locus_tag) : ''}</span></div><div class="mob-gfunc">${esc(g.functional_category ?? '')}</div></div>
+      <span class="mob-chev">${chev}</span>${i < genes.length - 1 ? '<div class="mob-sep"></div>' : ''}
+    </div>`;
+  }).join('');
+
+  const mRows = mutants.map((m, i) => {
+    const col = MOB_TYPE_COLORS[m.mutation_type] ?? '#8b958f';
+    const glyph = m.mutation_type === 'deletion' ? 'Δ' : (m.mutation_type === 'chimera' || m.mutation_type === 'recombination') ? '×' : '::';
+    return `<div class="mob-grow" data-saved-mut="${m.id}" style="background:var(--mob-paper);">
+      <div class="mob-bar" style="background:${col};"></div>
+      <div class="mob-thumb mob-stile" style="background:${col}14;display:grid;place-items:center;font-family:var(--mob-mono);font-weight:600;font-size:16px;color:${col};">${glyph}</div>
+      <div class="mob-meta"><div class="mob-gname" style="font-family:var(--mob-mono);font-weight:600;">${esc(m.name || m.mutant_id)}</div><div class="mob-gfunc">${esc(m.collection ?? '')}</div></div>
+      <span class="mob-chev">${chev}</span>${i < mutants.length - 1 ? '<div class="mob-sep"></div>' : ''}
+    </div>`;
+  }).join('');
+
+  const empty = `<div style="padding:28px 20px;text-align:center;color:var(--mob-ink-3);font-size:14px;">Nothing saved yet.<br>Tap ★ on any gene or mutant.</div>`;
+
+  const backdrop = document.createElement('div');
+  backdrop.id = 'mob-saved-sheet';
+  backdrop.className = 'mob-sheet-backdrop';
+  backdrop.innerHTML = `
+    <div class="mob-sheet" onclick="event.stopPropagation()" style="max-height:76vh;overflow-y:auto;padding:10px 0 calc(env(safe-area-inset-bottom,14px)+12px);">
+      <div class="mob-sheet-handle"></div>
+      <div style="display:flex;align-items:center;gap:8px;padding:4px 20px 12px;">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="#e8b400" stroke="#e8b400" stroke-width="1.5"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+        <span style="font-weight:800;font-size:17px;color:var(--mob-ink);">Saved</span>
+        <span style="color:var(--mob-ink-3);font-size:13px;font-weight:600;">· ${genes.length + mutants.length}</span>
+      </div>
+      ${genes.length || mutants.length
+        ? (genes.length   ? secH('Genes',   genes.length)   + `<div style="background:var(--mob-paper);">${gRows}</div>` : '')
+        + (mutants.length ? secH('Mutants', mutants.length) + `<div style="background:var(--mob-paper);">${mRows}</div>` : '')
+        : empty}
+    </div>`;
+
+  backdrop.addEventListener('click', () => backdrop.remove());
+  backdrop.querySelectorAll('[data-saved-gene]').forEach(row => {
+    row.addEventListener('click', () => { backdrop.remove(); window.__openGeneId = row.dataset.savedGene; activateTab('genomes'); });
+  });
+  backdrop.querySelectorAll('[data-saved-mut]').forEach(row => {
+    row.addEventListener('click', () => { backdrop.remove(); _mobLoadMutantDetail(row.dataset.savedMut); });
+  });
+  document.body.appendChild(backdrop);
 }
 
 // ─── Collapsing nav bar ─────────────────────────────────────
@@ -196,8 +270,8 @@ function initMobileShell() {
     });
   }
 
-  document.getElementById('mob-btn-saved')?.addEventListener('click', (e) => {
-    showSavedPopover(e.currentTarget);
+  document.getElementById('mob-btn-saved')?.addEventListener('click', () => {
+    pushMobileSaved();
   });
 
   document.getElementById('mob-btn-account')?.addEventListener('click', () => {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1,7 +1,7 @@
 // ChlamAtlas — main application entry point
 import { sb, state, SUPABASE_URL, SUPABASE_ANON_KEY, syncFavoritesFromDB } from './client.js?v=82';
 import { renderHome } from './views/home.js?v=82';
-import { renderGenomes } from './views/genomes.js?v=100';
+import { renderGenomes } from './views/genomes.js?v=101';
 import { renderMutants } from './views/mutants.js?v=96';
 import { renderPipeline } from './views/pipeline.js?v=82';
 import { renderRoadmap }  from './views/roadmap.js?v=91';

--- a/web/js/views/genomes.js
+++ b/web/js/views/genomes.js
@@ -89,6 +89,23 @@ const POPULAR_FILTERS = [
   { type: 'char',  value: 'secreted',                   label: 'T3 Secreted' },
 ];
 
+// Mutant-type filter chips shown per strain in the mobile filter bar More panel.
+// field: column on the mutants table; value: the DB value to match.
+const MUTANT_FILTERS_BY_STRAIN = {
+  'CT-L2': [
+    { label: 'Tn',       field: 'mutation_type', value: 'transposon'  },
+    { label: 'Deletion', field: 'mutation_type', value: 'recombination' },
+    { label: 'Lucky 17', field: 'collection',    value: 'Lucky17'     },
+    { label: 'Chimera',  field: 'collection',    value: 'Chimeras'    },
+  ],
+  'CT-D': [],
+  'CM': [
+    { label: 'Tn',       field: 'mutation_type', value: 'transposon'  },
+    { label: 'Deletion', field: 'mutation_type', value: 'recombination' },
+    { label: 'Chimera',  field: 'collection',    value: 'Chimeras'    },
+  ],
+};
+
 const PAGE_SIZE = 50;
 
 // ── Module-level state (reset on each renderGenomes call) ──
@@ -104,6 +121,7 @@ let _categoryFilter    = null;
 let _locationFilter    = null;  // SL or GO term id set by clicking a localization pill
 let _expressionFilter  = null;  // 'Early' | 'Mid' | 'Late' | 'Constitutive'
 let _ebRbFilter        = null;  // 'eb' | 'rb'
+let _mutantFilter      = null;  // { field, value, label } — set by mobile Mutants section
 let _offset         = 0;
 let _total       = 0;
 let _hasMore     = false;
@@ -124,7 +142,7 @@ let _sectionOpen = {
 };
 
 // Which More-panel sections are expanded (persists across filter bar re-renders)
-let _expandedSections = { characterization: false, function: false, location: false, structure: false, expression: false };
+let _expandedSections = { characterization: false, function: false, location: false, structure: false, expression: false, mutants: false };
 
 // HTML-escape helper for DB strings interpolated into innerHTML.
 const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
@@ -142,11 +160,11 @@ export function renderGenomes(container) {
 
   _loading = false; // reset in case a previous in-flight fetch was abandoned
   _search = ''; _offset = 0; _selectedId = null; _categoryFilter = null; _locationFilter = null;
-  _expressionFilter = null; _ebRbFilter = null;
+  _expressionFilter = null; _ebRbFilter = null; _mutantFilter = null;
   _filters = { favorites: false, characterized: false, hypothetical: false, inc: false,
                membrane: false, secreted: false, dnaBinding: false,
                hasAf3: false, hasCrystal: false };
-  _expandedSections = { characterization: false, function: false, location: false, structure: false, expression: false };
+  _expandedSections = { characterization: false, function: false, location: false, structure: false, expression: false, mutants: false };
   showGeneList(container);
 
   // If a gene was requested, open its detail panel immediately without waiting for list
@@ -239,7 +257,11 @@ function _renderMobileGeneList(container) {
   });
 
   const mobFetchFn = c => _mobFetchGenes(c);
-  renderFilterBar(container, false, mobFetchFn);
+  const mobFilterOpts = {
+    hideSections: ['location'],
+    mutantFilters: MUTANT_FILTERS_BY_STRAIN[_strain] ?? [],
+  };
+  renderFilterBar(container, false, mobFetchFn, mobFilterOpts);
 
   // Dismiss sort dropdown on outside click (same as desktop)
   document.addEventListener('click', () => {
@@ -313,6 +335,25 @@ async function _mobFetchGenes(container) {
     }
   }
 
+  // Mutant filter: two-step — find gene IDs with matching mutants, then filter genes
+  if (_mutantFilter) {
+    const { data: mutantRows } = await sb.from('mutants')
+      .select('target_gene_ids,strains!inner(common_name)')
+      .eq(_mutantFilter.field, _mutantFilter.value)
+      .eq('strains.common_name', _strain);
+    const geneIds = [...new Set((mutantRows ?? []).flatMap(m => m.target_gene_ids ?? []))];
+    if (!geneIds.length) {
+      _loading = false;
+      _total = 0; _hasMore = false; _offset = 0;
+      const countEl = container.querySelector('#mob-gene-count');
+      if (countEl) countEl.textContent = '0 genes';
+      const liveList = container.querySelector('#mob-gene-list');
+      if (liveList) liveList.innerHTML = '<div style="padding:24px 20px;color:var(--mob-ink-3);font-size:14px;text-align:center;">No genes found.</div>';
+      return;
+    }
+    query = query.in('id', geneIds);
+  }
+
   let data, count;
   try {
     ({ data, count } = await query);
@@ -381,8 +422,8 @@ async function _mobFetchGenes(container) {
 function _mobGroupAndRenderGenes(genes) {
   if (!genes.length) return '';
 
-  // Locus-tag sort: no section headers (they'd just be uninformative "CTL0___" labels)
-  if (_sortField === 'locus_tag') {
+  // No section headers for locus-tag or genomic-order sorts — grouping adds no info
+  if (_sortField === 'locus_tag' || _sortField === 'sort_index') {
     return `<div style="background:var(--mob-paper);">
       ${genes.map((g, i) => _mobGeneRow(g, i < genes.length - 1)).join('')}
     </div>`;
@@ -663,8 +704,10 @@ const SORT_OPTIONS = [
   { field: 'sort_index', asc: true,  label: 'Genomic order' },
 ];
 
-function renderFilterBar(container, expandMore = false, fetchFn = null) {
+function renderFilterBar(container, expandMore = false, fetchFn = null, opts = {}) {
   const doFetch = fetchFn ?? ((c) => fetchGenes(c, true));
+  const { hideSections = [], mutantFilters = [] } = opts;
+  const rerender = (open = false) => renderFilterBar(container, open, doFetch, opts);
   const bar = container.querySelector('#filter-bar');
   if (!bar) return;
 
@@ -727,7 +770,7 @@ function renderFilterBar(container, expandMore = false, fetchFn = null) {
 
   const activeChar   = CHAR_FILTERS.filter(f => _filters[f.id]);
   const activeStruct = STRUCT_FILTERS.filter(f => _filters[f.id]);
-  const anyActive    = activeChar.length || activeStruct.length || _locationFilter || _categoryFilter || _expressionFilter || _ebRbFilter;
+  const anyActive    = activeChar.length || activeStruct.length || _locationFilter || _categoryFilter || _expressionFilter || _ebRbFilter || _mutantFilter;
 
   // Section open state is purely user-controlled — no forced-open based on active filters
   const secOpen = {
@@ -736,18 +779,28 @@ function renderFilterBar(container, expandMore = false, fetchFn = null) {
     location:         _expandedSections.location,
     structure:        _expandedSections.structure,
     expression:       _expandedSections.expression,
+    mutants:          _expandedSections.mutants,
   };
 
   const groupHead = (id, icon, label, isOpen, hint = '') => `
     <button data-section="${id}"
-      style="display:flex;align-items:center;gap:4px;font-size:8.5px;font-weight:700;text-transform:uppercase;
-             letter-spacing:0.07em;color:#888;width:100%;margin-top:6px;border-top:1px solid #efefef;
-             padding-top:7px;padding-bottom:${isOpen ? '4px' : '2px'};background:none;border-left:none;
+      style="display:flex;align-items:center;gap:5px;font-size:11px;font-weight:700;text-transform:uppercase;
+             letter-spacing:0.05em;color:#777;width:100%;margin-top:6px;border-top:1px solid #efefef;
+             padding-top:8px;padding-bottom:${isOpen ? '5px' : '3px'};background:none;border-left:none;
              border-right:none;border-bottom:none;cursor:pointer;text-align:left;font-family:inherit;">
       <span>${icon}</span><span>${label}</span>
-      <span style="margin-left:auto;font-size:9px;color:#ccc;">${isOpen ? '▾' : '▸'}</span>
-      ${!isOpen && hint ? `<span style="font-size:8px;color:#bbb;font-weight:400;margin-left:2px;">${hint}</span>` : ''}
+      <span style="margin-left:auto;font-size:10px;color:#ccc;">${isOpen ? '▾' : '▸'}</span>
+      ${!isOpen && hint ? `<span style="font-size:9px;color:#bbb;font-weight:400;margin-left:2px;">${hint}</span>` : ''}
     </button>`;
+
+  const mutantChip = (f) => {
+    const active = _mutantFilter?.field === f.field && _mutantFilter?.value === f.value;
+    return `<button data-mutant-filter='${JSON.stringify({field:f.field,value:f.value,label:f.label})}'
+      style="font-size:10.5px;font-weight:600;padding:3px 9px;border-radius:20px;border:1px solid ${active ? '#fde68a' : '#e5e7eb'};
+             background:${active ? '#fefce8' : 'white'};color:${active ? '#92400e' : '#9ca3af'};cursor:pointer;white-space:nowrap;font-family:inherit;">
+      ${active ? '🔬 ' : ''}${esc(f.label)}${active ? ' ×' : ''}
+    </button>`;
+  };
 
   const startOpen = expandMore || anyActive || false;
 
@@ -770,10 +823,11 @@ function renderFilterBar(container, expandMore = false, fetchFn = null) {
       ${chip('favorites', '★ Favorites', _filters.favorites)}
       ${activeChar.map(f => chip(f.id, f.label, true)).join('')}
       ${activeStruct.map(f => chip(f.id, f.label, true, f.title)).join('')}
-      ${_categoryFilter   ? `<button data-clear-category   style="font-size:10.5px;font-weight:600;padding:3px 9px;border-radius:20px;border:1px solid #fde68a;background:#fefce8;color:#92400e;cursor:pointer;white-space:nowrap;font-family:inherit;">⚙️ ${esc(funcLabel(_categoryFilter))} ×</button>` : ''}
-      ${_locationFilter   ? `<button data-clear-location   style="font-size:10.5px;font-weight:600;padding:3px 9px;border-radius:20px;border:1px solid #bfdbfe;background:#eff6ff;color:#1d4ed8;cursor:pointer;white-space:nowrap;font-family:inherit;">📍 ${esc(locTermLabel(_locationFilter))} ×</button>` : ''}
+      ${_categoryFilter ? `<button data-clear-category style="font-size:10.5px;font-weight:600;padding:3px 9px;border-radius:20px;border:1px solid #fde68a;background:#fefce8;color:#92400e;cursor:pointer;white-space:nowrap;font-family:inherit;">⚙️ ${esc(funcLabel(_categoryFilter))} ×</button>` : ''}
+      ${_locationFilter ? `<button data-clear-location style="font-size:10.5px;font-weight:600;padding:3px 9px;border-radius:20px;border:1px solid #bfdbfe;background:#eff6ff;color:#1d4ed8;cursor:pointer;white-space:nowrap;font-family:inherit;">📍 ${esc(locTermLabel(_locationFilter))} ×</button>` : ''}
       ${_expressionFilter ? `<button data-clear-expression style="font-size:10.5px;font-weight:600;padding:3px 9px;border-radius:20px;border:1px solid #a5f3fc;background:#ecfeff;color:#164e63;cursor:pointer;white-space:nowrap;font-family:inherit;">📈 ${esc(_expressionFilter)} ×</button>` : ''}
       ${_ebRbFilter ? `<button data-clear-ebrb style="font-size:10.5px;font-weight:600;padding:3px 9px;border-radius:20px;border:1px solid #a5f3fc;background:#ecfeff;color:#164e63;cursor:pointer;white-space:nowrap;font-family:inherit;">📈 ${_ebRbFilter === 'eb' ? 'EB enriched' : 'RB enriched'} ×</button>` : ''}
+      ${_mutantFilter ? `<button data-clear-mutant style="font-size:10.5px;font-weight:600;padding:3px 9px;border-radius:20px;border:1px solid #fde68a;background:#fefce8;color:#92400e;cursor:pointer;white-space:nowrap;font-family:inherit;">🔬 ${esc(_mutantFilter.label)} ×</button>` : ''}
       <button id="more-filters-btn"
         style="font-size:10.5px;font-weight:600;color:${startOpen ? '#16a34a' : '#9ca3af'};background:white;border:1px solid ${startOpen ? '#bbf7d0' : '#e5e7eb'};border-radius:6px;padding:3px 9px;cursor:pointer;margin-left:auto;font-family:inherit;">
         ${startOpen ? '− Less' : '+ More'}
@@ -788,12 +842,13 @@ function renderFilterBar(container, expandMore = false, fetchFn = null) {
       <div style="display:${secOpen.function ? 'flex' : 'none'};flex-wrap:wrap;gap:5px;padding-bottom:4px;">
         ${FUNC_FILTERS.map(f => catChip(f.value, f.label)).join('')}
       </div>
+      ${!hideSections.includes('location') ? `
       ${groupHead('location', '📍', 'Location', secOpen.location, '— click a pill on any gene')}
       <div style="display:${secOpen.location ? 'flex' : 'none'};flex-wrap:wrap;gap:5px;padding-bottom:4px;">
         ${_locationFilter
           ? `<button data-clear-location style="font-size:10.5px;font-weight:600;padding:3px 9px;border-radius:20px;border:1px solid #bfdbfe;background:#eff6ff;color:#1d4ed8;cursor:pointer;white-space:nowrap;font-family:inherit;">📍 ${esc(locTermLabel(_locationFilter))} ×</button>`
           : `<span style="font-size:9px;color:#bbb;padding:2px 0;">Click a location pill on any gene to filter</span>`}
-      </div>
+      </div>` : ''}
       ${groupHead('structure', '🧊', 'Structure', secOpen.structure)}
       <div style="display:${secOpen.structure ? 'flex' : 'none'};flex-wrap:wrap;gap:5px;padding-bottom:4px;">
         ${STRUCT_FILTERS.map(f => chip(f.id, f.label, _filters[f.id], f.title)).join('')}
@@ -803,6 +858,11 @@ function renderFilterBar(container, expandMore = false, fetchFn = null) {
         ${EXPR_FILTERS.map(f => exprChip(f.value, f.label)).join('')}
         ${_strain === 'CT-L2' ? ebRbChip('eb', 'EB enriched') + ebRbChip('rb', 'RB enriched') : ''}
       </div>
+      ${mutantFilters.length ? `
+      ${groupHead('mutants', '🔬', 'Mutants', secOpen.mutants, '— genes with this mutant type')}
+      <div style="display:${secOpen.mutants ? 'flex' : 'none'};flex-wrap:wrap;gap:5px;padding-bottom:4px;">
+        ${mutantFilters.map(f => mutantChip(f)).join('')}
+      </div>` : ''}
     </div>
   `;
 
@@ -818,7 +878,7 @@ function renderFilterBar(container, expandMore = false, fetchFn = null) {
       _sortField = btn.dataset.sortField;
       _sortAsc   = btn.dataset.sortAsc === 'true';
       _offset = 0;
-      renderFilterBar(container, false, doFetch);
+      rerender();
       doFetch(container);
     });
   });
@@ -828,7 +888,7 @@ function renderFilterBar(container, expandMore = false, fetchFn = null) {
     btn.addEventListener('click', () => {
       const id = btn.dataset.section;
       _expandedSections[id] = !secOpen[id];
-      renderFilterBar(container, true, doFetch);
+      rerender(true);
     });
   });
 
@@ -838,7 +898,7 @@ function renderFilterBar(container, expandMore = false, fetchFn = null) {
       const key = btn.dataset.filter;
       _filters[key] = !_filters[key];
       _offset = 0;
-      renderFilterBar(container, startOpen, doFetch);
+      rerender(startOpen);
       doFetch(container);
     });
   });
@@ -849,7 +909,7 @@ function renderFilterBar(container, expandMore = false, fetchFn = null) {
       const val = btn.dataset.catFilter;
       _categoryFilter = _categoryFilter === val ? null : val;
       _offset = 0;
-      renderFilterBar(container, true, doFetch);
+      rerender(true);
       doFetch(container);
     });
   });
@@ -858,7 +918,7 @@ function renderFilterBar(container, expandMore = false, fetchFn = null) {
   bar.querySelector('[data-clear-category]')?.addEventListener('click', () => {
     _categoryFilter = null;
     _offset = 0;
-    renderFilterBar(container, false, doFetch);
+    rerender();
     doFetch(container);
   });
 
@@ -867,7 +927,7 @@ function renderFilterBar(container, expandMore = false, fetchFn = null) {
     btn.addEventListener('click', () => {
       _locationFilter = null;
       _offset = 0;
-      renderFilterBar(container, false, doFetch);
+      rerender();
       doFetch(container);
     });
   });
@@ -878,7 +938,7 @@ function renderFilterBar(container, expandMore = false, fetchFn = null) {
       const val = btn.dataset.exprFilter;
       _expressionFilter = _expressionFilter === val ? null : val;
       _offset = 0;
-      renderFilterBar(container, true, doFetch);
+      rerender(true);
       doFetch(container);
     });
   });
@@ -887,7 +947,7 @@ function renderFilterBar(container, expandMore = false, fetchFn = null) {
   bar.querySelector('[data-clear-expression]')?.addEventListener('click', () => {
     _expressionFilter = null;
     _offset = 0;
-    renderFilterBar(container, false, doFetch);
+    rerender();
     doFetch(container);
   });
 
@@ -897,7 +957,7 @@ function renderFilterBar(container, expandMore = false, fetchFn = null) {
       const val = btn.dataset.ebrbFilter;
       _ebRbFilter = _ebRbFilter === val ? null : val;
       _offset = 0;
-      renderFilterBar(container, true, doFetch);
+      rerender(true);
       doFetch(container);
     });
   });
@@ -906,7 +966,27 @@ function renderFilterBar(container, expandMore = false, fetchFn = null) {
   bar.querySelector('[data-clear-ebrb]')?.addEventListener('click', () => {
     _ebRbFilter = null;
     _offset = 0;
-    renderFilterBar(container, false, doFetch);
+    rerender();
+    doFetch(container);
+  });
+
+  // Mutant type filter chips
+  bar.querySelectorAll('[data-mutant-filter]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const f = JSON.parse(btn.dataset.mutantFilter);
+      const alreadyActive = _mutantFilter?.field === f.field && _mutantFilter?.value === f.value;
+      _mutantFilter = alreadyActive ? null : f;
+      _offset = 0;
+      rerender(true);
+      doFetch(container);
+    });
+  });
+
+  // Clear mutant filter
+  bar.querySelector('[data-clear-mutant]')?.addEventListener('click', () => {
+    _mutantFilter = null;
+    _offset = 0;
+    rerender();
     doFetch(container);
   });
 

--- a/web/js/views/genomes.js
+++ b/web/js/views/genomes.js
@@ -2992,54 +2992,13 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
     }
 
     // ── Structure ──
-    const afRows  = p?.alphafold_results ?? [];
-    const af3     = afRows.find(r => r.af_version === 'AF3');
-    const bestAf  = af3 ?? afRows.find(r => r.af_version === 'AF2' || r.af_version === 'AFDB') ?? afRows[0];
-    const mmcif   = bestAf?.mmcif_path ?? null;
-    const homolog = bestAf?.top_homolog_description ?? null;
-    const pdbId   = bestAf?.top_homolog_pdb_id ?? null;
-    const inferFn = bestAf?.inferred_function ?? null;
-
-    const metaEl = scroll.querySelector('#mob-structure-meta');
-    if (metaEl && (homolog || inferFn)) {
-      metaEl.innerHTML = `
-        ${homolog ? `<div style="font-size:13px;font-weight:600;color:var(--mob-ink);margin-bottom:2px;">${esc(homolog)}${pdbId ? ` <span style="font-family:var(--mob-mono);font-size:11px;color:var(--mob-ink-3);">${esc(pdbId)}</span>` : ''}</div>` : ''}
-        ${inferFn ? `<div style="font-size:12.5px;color:#444;background:#f0fdf4;border-radius:8px;padding:8px 10px;border-left:3px solid #16a34a;line-height:1.5;margin-top:6px;"><strong style="color:#1a6b4a;">Inferred:</strong> ${esc(inferFn)}</div>` : ''}`;
-    }
-    const loadWrap = scroll.querySelector('#mob-struct-load-wrap');
-    if (loadWrap && mmcif) {
-      loadWrap.innerHTML = `<button id="mob-struct-3d-btn" style="margin-top:12px;width:100%;padding:10px;border-radius:10px;border:1.5px solid var(--mob-line);background:var(--mob-bg-warm);font-family:var(--mob-sans);font-size:14px;font-weight:700;color:var(--mob-green-ink);cursor:pointer;display:flex;align-items:center;justify-content:center;gap:8px;">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/></svg>
-        View in 3D
-      </button>`;
-      loadWrap.querySelector('#mob-struct-3d-btn').addEventListener('click', async (e) => {
-        const btn = e.currentTarget;
-        btn.textContent = 'Loading viewer…';
-        btn.disabled = true;
-        const container = document.createElement('div');
-        container.style.cssText = 'position:relative;width:100%;height:320px;border-radius:12px;overflow:hidden;margin-top:12px;background:#111;';
-        loadWrap.appendChild(container);
-        await loadMolstar(container, mmcif);
-        btn.remove();
-      });
-    }
+    _renderMobStructure(scroll, p);
 
     // ── Transcriptomics ──
     _renderMobTranscriptomics(scroll.querySelector('#mob-transcriptomics-inner'), gene, exprs);
 
     // ── EB / RB Proteomics ──
-    const protEl = scroll.querySelector('#mob-proteomics-inner');
-    if (protEl) {
-      if (!p || (p.eb_enriched == null && p.rb_enriched == null)) {
-        protEl.textContent = 'No proteomic data available';
-      } else {
-        protEl.innerHTML = `
-          <div class="mob-kv-grid">
-            <div class="mob-kv"><div class="mob-k">EB enriched</div><div class="mob-v sm">${p.eb_enriched ? 'Yes' : 'No'}</div></div>
-            <div class="mob-kv"><div class="mob-k">RB enriched</div><div class="mob-v sm">${p.rb_enriched ? 'Yes' : 'No'}</div></div>
-          </div>`;
-      }
-    }
+    _renderMobProteomics(scroll.querySelector('#mob-proteomics-inner'), gene, exprs);
 
     // ── Cell Localization ──
     _renderMobLocalization(scroll, gene, p);
@@ -3114,6 +3073,198 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
   }).catch(err => console.warn('[ChlamAtlas] gene detail fetch:', err));
 }
 
+function _renderMobStructure(scroll, p) {
+  const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  const structEl   = scroll.querySelector('#mob-structure-inner');
+  const metaEl     = scroll.querySelector('#mob-structure-meta');
+  const loadWrap   = scroll.querySelector('#mob-struct-load-wrap');
+  if (!structEl) return;
+
+  const afRows    = p?.alphafold_results ?? [];
+  const uniprotId = p?.uniprot_id ?? null;
+
+  const crystal      = afRows.find(r => r.af_version === 'crystal');
+  const af3Available = afRows.find(r => r.af_version === 'AF3' && r.mmcif_path);
+  const af2 = afRows.find(r => r.af_version === 'AF2' || r.af_version === 'AFDB')
+    ?? (uniprotId ? { af_version:'AF2', _synthetic:true, _uniprotId:uniprotId,
+                      mmcif_path:null, thumbnail_path:null, homology_score:null,
+                      ptm_score:null, top_homolog_pdb_id:null, top_homolog_description:null,
+                      homology_method:null, inferred_function:null } : null);
+
+  const tabs = [
+    ['crystal','Crystal',   crystal],
+    ['af3',    'AlphaFold 3', af3Available],
+    ['af2',    'AlphaFold 2', af2],
+  ].filter(([,,rec]) => rec);
+
+  if (!tabs.length) { structEl.innerHTML = '<div style="color:var(--mob-ink-3);font-size:13px;">No structure data</div>'; return; }
+
+  let activeTabId = crystal ? 'crystal' : af3Available ? 'af3' : 'af2';
+  let activeRecord = crystal ?? af3Available ?? af2;
+
+  const tabStyle = (id) =>
+    `font-family:var(--mob-sans);font-size:12px;font-weight:700;padding:5px 10px;border:none;
+     background:none;cursor:pointer;border-bottom:2px solid ${activeTabId===id?'var(--mob-green)':'transparent'};
+     color:${activeTabId===id?'var(--mob-green)':'var(--mob-ink-3)'};white-space:nowrap;transition:color .15s;`;
+
+  const tabRow = `<div id="mob-struct-tabs" style="display:flex;gap:0;overflow-x:auto;border-bottom:1px solid var(--mob-line);margin-bottom:10px;scrollbar-width:none;">
+    ${tabs.map(([id,label]) => `<button class="mob-struct-tab" data-tab="${id}" style="${tabStyle(id)}">${label}</button>`).join('')}
+  </div>`;
+
+  function bodyFor(rec) {
+    if (!rec) return '';
+    const thumb = rec.thumbnail_path;
+    const mmcif = rec.mmcif_path;
+    const recUniprot = rec._uniprotId ?? uniprotId;
+    const canLoad = mmcif || recUniprot;
+
+    let scoreHtml = '';
+    if (rec.af_version === 'AF3' && rec.ptm_score != null) {
+      scoreHtml = `<div style="display:flex;align-items:baseline;gap:6px;margin:8px 0;">
+        <span style="font-family:var(--mob-mono);font-size:20px;font-weight:700;color:${ptmColor(rec.ptm_score)};">${rec.ptm_score.toFixed(2)}</span>
+        <span style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--mob-ink-3);">pTM score</span>
+      </div>`;
+    } else if (rec.af_version === 'AF2' || rec.af_version === 'AFDB') {
+      const db = rec.homology_score;
+      const pre = db != null
+        ? `<span style="font-family:var(--mob-mono);font-size:20px;font-weight:700;color:${plddtColor(db)};">${db.toFixed(1)}</span>
+           <span style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--mob-ink-3);"> mean pLDDT · ${plddtLabel(db)}</span>` : '';
+      scoreHtml = `<div id="mob-af2-score" style="display:flex;align-items:baseline;gap:6px;margin:8px 0;min-height:28px;">${pre}</div>`;
+    }
+
+    let versionNote = '';
+    if (rec.af_version === 'AF3') versionNote = 'AlphaFold v3 (2024) diffusion-based predictions generated by the Hybiske Lab.';
+    else if (rec.af_version === 'AF2' || rec.af_version === 'AFDB') versionNote = 'AlphaFold v2 (2021) prediction from the EBI AlphaFold Database.';
+
+    const srcLabel = rec.af_version === 'crystal' ? 'Crystal Structure · RCSB PDB'
+      : rec.af_version === 'AF3' ? 'AlphaFold v3 · Hybiske Lab'
+      : 'AlphaFold v2 · AlphaFoldDB';
+
+    const homolog = (rec.af_version !== 'crystal' && rec.top_homolog_description)
+      ? `<div style="font-size:13px;font-weight:600;color:var(--mob-ink);margin-bottom:2px;">${esc(rec.top_homolog_description)}
+           ${rec.top_homolog_pdb_id ? `<span style="font-family:var(--mob-mono);font-size:11px;color:var(--mob-ink-3);"> ${esc(rec.top_homolog_pdb_id)}</span>` : ''}
+         </div>` : '';
+
+    const inferred = (rec.af_version !== 'crystal' && rec.inferred_function)
+      ? `<div style="font-size:12.5px;color:#444;background:#f0fdf4;border-radius:8px;padding:8px 10px;border-left:3px solid #16a34a;line-height:1.55;margin:8px 0;">
+           <strong style="color:#1a6b4a;">Inferred function:</strong> ${esc(rec.inferred_function)}</div>` : '';
+
+    const crystalId = rec.af_version === 'crystal' && rec.top_homolog_pdb_id
+      ? `<div style="font-family:var(--mob-mono);font-size:22px;font-weight:700;color:var(--mob-ink);margin:6px 0 2px;">${esc(rec.top_homolog_pdb_id)}</div>
+         <div id="mob-rcsb-detail" style="font-size:11px;color:var(--mob-ink-3);min-height:14px;margin-bottom:8px;"></div>` : '';
+
+    const viewerAttrs = (rec.af_version === 'AF2' || rec.af_version === 'AFDB') && recUniprot
+      ? `data-uniprot-id="${esc(recUniprot)}"`
+      : `data-url="${esc(mmcif ?? '')}"`;
+
+    return `
+      <div id="mob-struct-viewer-wrap" ${viewerAttrs}
+        style="position:relative;border-radius:12px;overflow:hidden;border:.5px solid var(--mob-line);background:#0a1628;height:240px;margin-bottom:10px;">
+        ${thumb ? `<img id="mob-struct-thumb" src="${esc(thumb)}" style="width:100%;height:100%;object-fit:contain;display:block;">` : ''}
+      </div>
+      <div style="font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--mob-ink-3);margin-bottom:4px;">${srcLabel}</div>
+      ${crystalId}
+      ${scoreHtml}
+      ${versionNote ? `<div style="font-size:11px;color:var(--mob-ink-3);line-height:1.5;margin-bottom:6px;">${versionNote}</div>` : ''}
+      ${homolog}${inferred}`;
+  }
+
+  structEl.innerHTML = tabRow + `<div id="mob-struct-body">${bodyFor(activeRecord)}</div>`;
+  if (metaEl) metaEl.innerHTML = '';
+  if (loadWrap) loadWrap.innerHTML = '';
+
+  // Wire tabs
+  const card = structEl.closest('.mob-card');
+  card?.querySelectorAll('.mob-struct-tab').forEach(btn => {
+    btn.addEventListener('click', () => {
+      activeTabId = btn.dataset.tab;
+      activeRecord = activeTabId === 'crystal' ? crystal : activeTabId === 'af3' ? af3Available : af2;
+      card.querySelectorAll('.mob-struct-tab').forEach(t => {
+        const on = t.dataset.tab === activeTabId;
+        t.style.color = on ? 'var(--mob-green)' : 'var(--mob-ink-3)';
+        t.style.borderBottomColor = on ? 'var(--mob-green)' : 'transparent';
+      });
+      card.querySelector('#mob-struct-body').innerHTML = bodyFor(activeRecord);
+      _setupMobMolstarObserver(card, activeRecord, uniprotId);
+      if (activeTabId === 'crystal' && activeRecord?.top_homolog_pdb_id) {
+        fetchRcsbMetadata(card.querySelector('#mob-struct-viewer-wrap')?.closest('div'), activeRecord.top_homolog_pdb_id);
+      }
+    });
+  });
+
+  _setupMobMolstarObserver(card, activeRecord, uniprotId);
+  if (activeTabId === 'crystal' && activeRecord?.top_homolog_pdb_id) {
+    fetchRcsbMetadata(card?.querySelector('#mob-struct-viewer-wrap')?.closest('div'), activeRecord.top_homolog_pdb_id);
+  }
+}
+
+function _setupMobMolstarObserver(card, record, uniprotId) {
+  const wrap = card?.querySelector('#mob-struct-viewer-wrap');
+  if (!wrap || wrap.dataset.molstarInitiated) return;
+  const url      = wrap.dataset.url;
+  const uniprot  = wrap.dataset.uniprotId;
+  if (!url && !uniprot) return;
+  wrap.dataset.molstarInitiated = 'true';
+
+  let fired = false;
+  const obs = new IntersectionObserver(entries => {
+    if (!entries[0].isIntersecting || fired) return;
+    fired = true;
+    obs.disconnect();
+    if (uniprot) {
+      // Provide a minimal panel-like object so loadMolstarViaAfdbApi can update the score display
+      const fakePanelEl = { querySelector: (sel) => sel === '#af2-score-display' ? card.querySelector('#mob-af2-score') : null };
+      loadMolstarViaAfdbApi(wrap, uniprot, fakePanelEl);
+    } else {
+      loadMolstar(wrap, url);
+    }
+  }, { threshold: 0.1 });
+  obs.observe(wrap);
+}
+
+function _renderMobProteomics(el, gene, exprs) {
+  if (!el) return;
+  const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+
+  // expression_data rows that have proteomics values (eb_expression / rb_expression)
+  const protRow = exprs.find(r => r.eb_expression != null || r.rb_expression != null) ?? null;
+
+  if (!protRow) {
+    el.innerHTML = '<div style="color:var(--mob-ink-3);font-size:13px;">No proteomic data available</div>';
+    return;
+  }
+
+  const ebVal  = protRow.eb_expression ?? 0;
+  const rbVal  = protRow.rb_expression ?? 0;
+  const maxVal = Math.max(ebVal, rbVal, 1);
+
+  const bar = (label, val) => {
+    const pct = Math.round((val / maxVal) * 100);
+    return `<div style="margin-bottom:10px;">
+      <div style="font-size:10.5px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--mob-ink-3);margin-bottom:4px;">${label}</div>
+      <div style="display:flex;align-items:center;gap:8px;">
+        <div style="height:6px;background:var(--mob-line-2);border-radius:3px;flex:1;">
+          <div style="height:6px;border-radius:3px;background:var(--mob-green);width:${pct}%;"></div>
+        </div>
+        <span style="font-family:var(--mob-mono);font-size:12px;color:var(--mob-ink);white-space:nowrap;">${val}</span>
+      </div>
+    </div>`;
+  };
+
+  const ebEnriched = gene.eb_enriched;
+  const rbEnriched = gene.rb_enriched;
+  const enrichLabel = ebEnriched ? 'EB enriched' : rbEnriched ? 'RB enriched' : null;
+  const enrichPill = enrichLabel
+    ? `<span style="display:inline-block;font-size:12px;font-weight:700;padding:4px 11px;border-radius:999px;background:#eef9f4;color:var(--mob-green-ink);border:1px solid rgba(47,158,110,.2);margin-top:4px;">${enrichLabel}</span>`
+    : '';
+
+  el.innerHTML = `
+    ${bar('EB (elementary body)', ebVal)}
+    ${bar('RB (reticulate body)', rbVal)}
+    ${enrichPill}
+    <div style="font-size:10.5px;color:var(--mob-ink-3);margin-top:8px;">CT-L2 spectral counts · Saka et al. 2011 · PMID 22014092</div>`;
+}
+
 function _renderMobTranscriptomics(el, gene, exprs) {
   if (!el) return;
   const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
@@ -3172,43 +3323,73 @@ function _renderMobLocalization(scroll, gene, protein) {
   if (!el) return;
   const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
 
-  const source   = protein?.localization_source ?? null;
-  const slTerms  = protein?.subcellular_location_sl ?? [];
-  const goTerms  = protein?.subcellular_location_go ?? [];
+  const source  = protein?.localization_source ?? null;
+  const slTerms = protein?.subcellular_location_sl ?? [];
+  const goTerms = protein?.subcellular_location_go ?? [];
+  const taxid   = Number(STRAIN_TAXID[gene.strains?.common_name]) || 813;
 
+  let diagramUrl  = null;
   let activeTerms = [];
   let sourceBadge = '';
-  const badgeHtml = (label, col, bg) =>
+  const badge = (label, col, bg) =>
     `<span style="font-size:10px;font-weight:700;padding:2px 8px;border-radius:6px;background:${bg};color:${col};letter-spacing:.04em;margin-left:auto;">${label}</span>`;
 
   if (source === 'user') {
+    diagramUrl  = slTerms.length ? `https://www.swissbiopics.org/api/${taxid}/sl/${slTerms.map(t => t.replace(/^SL-/,'')).join(',')}` : null;
     activeTerms = slTerms.map(id => ({ id, label: locTermLabel(id) }));
-    sourceBadge = badgeHtml('Curated', '#065f46', '#d1fae5');
+    sourceBadge = badge('Curated', '#065f46', '#d1fae5');
   } else if (source === 'lab_flag') {
+    diagramUrl  = `https://www.swissbiopics.org/api/${taxid}/sl/0243`;
     activeTerms = [{ id: 'SL-0204', label: 'Secreted' }];
-    sourceBadge = badgeHtml('ChlamAtlas', '#92400e', '#fef3c7');
+    sourceBadge = badge('ChlamAtlas', '#92400e', '#fef3c7');
   } else if (source === 'uniprot_sl') {
+    diagramUrl  = slTerms.length ? `https://www.swissbiopics.org/api/${taxid}/sl/${slTerms.map(t => t.replace(/^SL-/,'')).join(',')}` : null;
     activeTerms = slTerms.map(id => ({ id, label: locTermLabel(id) }));
-    sourceBadge = badgeHtml('UniProt', '#6b7280', '#f3f4f6');
+    sourceBadge = badge('UniProt', '#6b7280', '#f3f4f6');
   } else if (source === 'uniprot_go') {
+    const goIds = goTerms.map(t => t.replace(/^GO:/,'')).join(',');
+    diagramUrl  = goIds ? `https://www.swissbiopics.org/api/${taxid}/go/${goIds}` : null;
     activeTerms = goTerms.map(id => ({ id, label: locTermLabel(id) }));
-    sourceBadge = badgeHtml('GO', '#6b7280', '#f3f4f6');
+    sourceBadge = badge('GO', '#6b7280', '#f3f4f6');
   }
 
   if (headEl && sourceBadge) headEl.innerHTML = `Cell Localization ${sourceBadge}`;
 
   if (!activeTerms.length && !protein?.localization) {
-    el.innerHTML = '<div style="font-style:italic;color:var(--mob-ink-3);font-size:14px;">Location unknown</div>';
+    el.innerHTML = '<div style="color:var(--mob-ink-3);font-size:13px;">Location unknown</div>';
     return;
   }
 
   const pills = activeTerms.length
-    ? activeTerms.map(t => `<span style="font-size:12px;font-weight:700;padding:5px 12px;border-radius:999px;background:#f3f4f6;color:#374151;border:1px solid #e5e7eb;">${esc(t.label)}</span>`).join('')
-    : protein?.localization?.split(';').filter(Boolean).map(s => `<span style="font-size:12px;font-weight:700;padding:5px 12px;border-radius:999px;background:#f3f4f6;color:#374151;border:1px solid #e5e7eb;">${esc(s.trim())}</span>`).join('') ?? '';
+    ? activeTerms.map(t => `<span style="font-size:12.5px;font-weight:700;padding:5px 12px;border-radius:999px;background:#f3f4f6;color:#374151;border:1px solid #e5e7eb;">${esc(t.label)}</span>`).join('')
+    : (protein?.localization ?? '').split(';').filter(Boolean).map(s =>
+        `<span style="font-size:12.5px;font-weight:700;padding:5px 12px;border-radius:999px;background:#f3f4f6;color:#374151;border:1px solid #e5e7eb;">${esc(s.trim())}</span>`
+      ).join('');
 
-  el.innerHTML = pills
-    ? `<div style="display:flex;flex-wrap:wrap;gap:7px;">${pills}</div>`
-    : '<div style="font-style:italic;color:var(--mob-ink-3);font-size:14px;">Location unknown</div>';
+  // Render diagram container + pills
+  el.innerHTML = `
+    ${diagramUrl ? `<div id="mob-sbp-svg" style="max-width:100%;overflow:hidden;margin-bottom:10px;display:flex;align-items:center;justify-content:center;min-height:60px;">
+      <div style="color:var(--mob-ink-3);font-size:12px;">Loading diagram…</div>
+    </div>` : ''}
+    ${pills ? `<div style="display:flex;flex-wrap:wrap;gap:7px;">${pills}</div>` : ''}`;
+
+  // Fetch SwissBioPics SVG
+  if (diagramUrl) {
+    const svgEl = el.querySelector('#mob-sbp-svg');
+    fetch(diagramUrl)
+      .then(r => { if (!r.ok) throw new Error(r.status); return r.text(); })
+      .then(svg => {
+        if (!svgEl || !el.isConnected) return;
+        const responsive = svg
+          .replace(/(<svg\b[^>]*?)\s(?:width|height)="[^"]*"/g, '$1')
+          .replace(/(<svg\b[^>]*?)\s(?:width|height)="[^"]*"/g, '$1')
+          .replace('<svg', '<svg style="width:100%;height:auto;display:block;overflow:hidden;"');
+        svgEl.innerHTML = responsive;
+      })
+      .catch(() => {
+        if (svgEl) svgEl.innerHTML = '<div style="color:var(--mob-ink-3);font-size:11px;padding:4px 0;">Diagram unavailable</div>';
+      });
+  }
 }
 
 async function _buildMobGenomicContext(gene, inner) {

--- a/web/js/views/genomes.js
+++ b/web/js/views/genomes.js
@@ -307,6 +307,7 @@ async function _mobFetchGenes(container) {
       'id,locus_tag,gene_name,gene_symbol,product,functional_category,' +
       'is_characterized,is_hypothetical,is_t3_secreted,is_membrane_protein,' +
       'sort_index,strand,start_bp,end_bp,strain_id,updated_at,updated_by,' +
+      'dna_sequence,' +
       'strains!inner(common_name),' +
       'proteins(alphafold_results(thumbnail_path))',
       { count: 'exact' }
@@ -3085,9 +3086,12 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
           if (!g) return '';
           const strainName  = g.strains?.common_name ?? '?';
           const strainIcon  = STRAIN_ICONS[strainName];
-          // Bold = locus_tag + gene_name (if any) in one line — no redundant secondary tag
-          const displayText = g.gene_name
-            ? `${esc(g.locus_tag)} <span style="color:var(--mob-ink-3);font-weight:400;">${esc(g.gene_name)}</span>`
+          // Some genes store gene_name as "symbol locus_tag" — strip the trailing locus_tag
+          let geneSym = (g.gene_name || '').trim();
+          if (geneSym.endsWith(g.locus_tag)) geneSym = geneSym.slice(0, -g.locus_tag.length).trim();
+          // Single bold black line: "CT633 hemB" or just "CT633"
+          const displayText = geneSym
+            ? `${esc(g.locus_tag)} ${esc(geneSym)}`
             : esc(g.locus_tag);
           const iconEl = strainIcon
             ? `<img src="${strainIcon}" alt="${strainName}" style="width:32px;height:32px;object-fit:contain;flex-shrink:0;">`
@@ -3137,11 +3141,13 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
             ? `<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--mob-ink-3)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0;"><rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>` : '';
           const divider   = i < mutants.length - 1 ? 'border-bottom:1px solid var(--mob-line);' : '';
           return `<div data-mut-id="${m.id}" style="display:flex;align-items:center;gap:10px;padding:10px 0;cursor:pointer;${divider}">
-            <div style="width:4px;min-height:38px;border-radius:3px;background:${col};flex-shrink:0;align-self:stretch;"></div>
+            <div style="width:4px;min-height:34px;border-radius:3px;background:${col};flex-shrink:0;align-self:stretch;"></div>
             <div style="flex:1;min-width:0;">
-              <div style="font-size:14.5px;font-weight:700;color:var(--mob-ink);">${esc(primary)}</div>
-              ${secondary ? `<div style="font-size:12px;color:var(--mob-ink-3);margin-top:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${esc(secondary)}</div>` : ''}
-              <div style="margin-top:5px;">${typePill}</div>
+              <div style="display:flex;align-items:center;gap:7px;flex-wrap:wrap;">
+                <span style="font-size:14.5px;font-weight:700;color:var(--mob-ink);">${esc(primary)}</span>
+                ${typePill}
+              </div>
+              ${secondary ? `<div style="font-size:12px;color:var(--mob-ink-3);margin-top:3px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${esc(secondary)}</div>` : ''}
             </div>
             ${lockIcon}
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#c8cec9" stroke-width="2.2" stroke-linecap="round"><polyline points="9 18 15 12 9 6"/></svg>

--- a/web/js/views/genomes.js
+++ b/web/js/views/genomes.js
@@ -140,6 +140,7 @@ export function renderGenomes(container) {
   delete window.__openGeneId;
   delete window.__geneDetailId;
 
+  _loading = false; // reset in case a previous in-flight fetch was abandoned
   _search = ''; _offset = 0; _selectedId = null; _categoryFilter = null; _locationFilter = null;
   _expressionFilter = null; _ebRbFilter = null;
   _filters = { favorites: false, characterized: false, hypothetical: false, inc: false,
@@ -159,7 +160,7 @@ export function renderGenomes(container) {
 async function openGeneById(geneId, container) {
   const cached = _geneCache.get(String(geneId));
   if (cached) {
-    showGeneDetailDesktop(cached, container);
+    _openGeneByData(cached, container);
     return;
   }
   const { data } = await sb.from('genes')
@@ -168,19 +169,29 @@ async function openGeneById(geneId, container) {
       'start_bp,end_bp,strand,functional_category,is_characterized,' +
       'is_membrane_protein,is_hypothetical,is_dna_binding,is_t3_secreted,' +
       'expression_pattern,eb_enriched,rb_enriched,dna_sequence,' +
-      'strains!inner(common_name,color_hex)'
+      'strains!inner(common_name,color_hex),' +
+      'proteins(alphafold_results(thumbnail_path))'
     )
     .eq('id', geneId)
     .single();
   if (data) {
     _geneCache.set(String(data.id), data);
-    showGeneDetailDesktop(data, container);
+    _openGeneByData(data, container);
   }
+}
+
+function _openGeneByData(gene, container) {
+  if (isMobileViewport()) showGeneDetailMobile(gene, container);
+  else showGeneDetailDesktop(gene, container);
 }
 
 // ─── Mobile gene list ─────────────────────────────────────
 function _renderMobileGeneList(container) {
   const currentStrain = STRAINS.find(s => s.id === _strain) ?? STRAINS[0];
+
+  // Reset scroll wiring so the listener re-attaches for any container changes
+  const panel = document.getElementById('tab-genomes');
+  if (panel) panel._mobScrollWired = false;
 
   container.style.padding = '0';
   container.innerHTML = `
@@ -339,8 +350,9 @@ async function _mobFetchGenes(container) {
   const countEl = container.querySelector('#mob-gene-count');
   if (countEl) countEl.textContent = `${_total.toLocaleString()} genes`;
 
+  const isFirstPage = (_offset - data.length) === 0;
   const html = _mobGroupAndRenderGenes(data);
-  if (_offset <= data.length) {
+  if (isFirstPage) {
     list.innerHTML = html || '<div style="padding:24px 20px;color:var(--mob-ink-3);font-size:14px;text-align:center;">No genes found.</div>';
   } else {
     list.insertAdjacentHTML('beforeend', html);
@@ -349,13 +361,13 @@ async function _mobFetchGenes(container) {
   list.querySelectorAll('.mob-grow:not([data-wired])').forEach(row => {
     row.dataset.wired = '1';
     row.addEventListener('click', e => {
-      if (e.target.closest('.mob-star')) return; // handled by delegation below
+      if (e.target.closest('.mob-star')) return;
       const gene = _geneCache.get(row.dataset.id);
       if (gene) showGeneDetailMobile(gene, container);
     });
   });
 
-  // Star toggle delegation — wire once on the list container
+  // Star toggle delegation — wire once
   if (!list.dataset.starWired) {
     list.dataset.starWired = '1';
     list.addEventListener('click', async e => {
@@ -371,6 +383,7 @@ async function _mobFetchGenes(container) {
     });
   }
 
+  // Set up infinite scroll once (panel._mobScrollWired prevents double-setup)
   _mobSetupInfiniteScroll(container);
 }
 
@@ -446,18 +459,19 @@ function _mobGeneRow(g, hasSep) {
 }
 
 function _mobSetupInfiniteScroll(container) {
-  if (!_hasMore) return;
-  const sentinel = container.querySelector('#mob-gene-sentinel');
-  if (!sentinel) return;
-  if (sentinel._obs) {
-    sentinel._obs.disconnect();
-    sentinel._obs = null;
-  }
-  const obs = new IntersectionObserver(entries => {
-    if (entries[0].isIntersecting && !_loading && _hasMore) _mobFetchGenes(container);
-  }, { root: container, threshold: 0 });
-  obs.observe(sentinel);
-  sentinel._obs = obs;
+  // Attach a scroll listener to the tab-panel (the actual overflow scroll container).
+  // IntersectionObserver with root:null incorrectly reports items in a
+  // position:fixed overflow container as intersecting on initial fire.
+  const panel = document.getElementById('tab-genomes');
+  if (!panel || panel._mobScrollWired) return;
+  panel._mobScrollWired = true;
+
+  panel.addEventListener('scroll', () => {
+    if (!_loading && _hasMore) {
+      const nearBottom = panel.scrollTop + panel.clientHeight >= panel.scrollHeight - 300;
+      if (nearBottom) _mobFetchGenes(container);
+    }
+  }, { passive: true });
 }
 
 function _showMobStrainSheet(container) {
@@ -2795,10 +2809,6 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
     return `rgba(${r},${g},${b},${a})`;
   };
 
-  const productPill = gene.product
-    ? `<span class="mob-tag" style="color:#4a5650;border-color:#c8d0cb;background:#f0f2f0;font-weight:600;text-transform:none;font-size:10.5px;max-width:260px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${esc(gene.product.length > 55 ? gene.product.slice(0,52) + '…' : gene.product)}</span>`
-    : '';
-
   scroll.innerHTML = `
     <!-- ── Header: gradient bleed ── -->
     <div style="margin-top:calc(-1 * var(--mob-nav-h));padding-top:calc(var(--mob-nav-h) + 10px);
@@ -2827,13 +2837,14 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
         ${gene.is_characterized ? `<span class="mob-tag" style="color:#1c8c7e;border-color:#1c8c7e;background:rgba(28,140,126,.08);">Characterized</span>` : ''}
         ${gene.is_t3_secreted   ? `<span class="mob-tag" style="color:#7c3aed;border-color:#7c3aed;background:rgba(124,58,237,.08);">T3 Secreted</span>` : ''}
         ${gene.is_dna_binding   ? `<span class="mob-tag" style="color:#b45309;border-color:#b45309;background:rgba(180,83,9,.08);">DNA Binding</span>` : ''}
-        ${productPill}
       </div>
       <div class="mob-meta-row" style="padding:10px 16px 0;">
         <a class="mob-copybtn" href="https://www.uniprot.org/uniprot/?query=${esc(gene.locus_tag)}" target="_blank" rel="noopener">UniProt ↗</a>
         <a class="mob-copybtn" href="https://www.ncbi.nlm.nih.gov/gene/?term=${esc(gene.locus_tag)}" target="_blank" rel="noopener">NCBI ↗</a>
       </div>
     </div>
+
+    <!-- Desktop L→R top→bottom: Gene Info | Orthologs → Gene Map → Protein | Localization → Transcriptomics → Proteomics → Structure → Mutants -->
 
     <!-- ── Gene Info ── -->
     <div class="mob-card">
@@ -2844,6 +2855,12 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
         <div class="mob-kv"><div class="mob-k">Position</div><div class="mob-v sm">${gene.start_bp ? gene.start_bp.toLocaleString() + '–' + (gene.end_bp ?? '?').toLocaleString() : '—'}</div></div>
         <div class="mob-kv"><div class="mob-k">Organism</div><div class="mob-v sm">${esc(gene.strains?.common_name ?? _strain)}</div></div>
       </div>
+    </div>
+
+    <!-- ── Orthologs ── -->
+    <div class="mob-card">
+      <div class="mob-card-h">Orthologs</div>
+      <div id="mob-orthologs-inner" style="margin-top:10px;color:var(--mob-ink-3);font-size:13px;font-style:italic;">Loading…</div>
     </div>
 
     <!-- ── Genomic Context ── -->
@@ -2869,18 +2886,10 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
       </div>
     </div>
 
-    <!-- ── Structure ── -->
+    <!-- ── Cell Localization ── -->
     <div class="mob-card">
-      <div class="mob-card-h">Structure</div>
-      <div id="mob-structure-inner" style="margin-top:12px;">
-        ${thumb
-          ? `<div id="mob-struct-thumb-wrap" style="position:relative;border-radius:12px;overflow:hidden;border:.5px solid var(--mob-line);">
-               <img id="mob-struct-thumb" src="${esc(thumb)}" alt="AlphaFold structure" style="width:100%;max-height:200px;object-fit:contain;display:block;">
-             </div>`
-          : '<div style="color:var(--mob-ink-3);font-size:13px;font-style:italic;">No structure available</div>'}
-      </div>
-      <div id="mob-structure-meta" style="margin-top:10px;"></div>
-      <div id="mob-struct-load-wrap"></div>
+      <div class="mob-card-h" id="mob-loc-head">Cell Localization</div>
+      <div id="mob-loc-inner" style="margin-top:10px;color:var(--mob-ink-3);font-size:13px;font-style:italic;">Loading…</div>
     </div>
 
     <!-- ── Transcriptomics ── -->
@@ -2895,16 +2904,18 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
       <div id="mob-proteomics-inner" style="margin-top:12px;font-style:italic;color:var(--mob-ink-3);font-size:14px;">Loading…</div>
     </div>
 
-    <!-- ── Cell Localization ── -->
+    <!-- ── Structure ── -->
     <div class="mob-card">
-      <div class="mob-card-h" id="mob-loc-head">Cell Localization</div>
-      <div id="mob-loc-inner" style="margin-top:10px;color:var(--mob-ink-3);font-size:13px;font-style:italic;">Loading…</div>
-    </div>
-
-    <!-- ── Orthologs ── -->
-    <div class="mob-card">
-      <div class="mob-card-h">Orthologs</div>
-      <div id="mob-orthologs-inner" style="margin-top:10px;color:var(--mob-ink-3);font-size:13px;font-style:italic;">Loading…</div>
+      <div class="mob-card-h">Structure</div>
+      <div id="mob-structure-inner" style="margin-top:12px;">
+        ${thumb
+          ? `<div id="mob-struct-thumb-wrap" style="position:relative;border-radius:12px;overflow:hidden;border:.5px solid var(--mob-line);">
+               <img id="mob-struct-thumb" src="${esc(thumb)}" alt="AlphaFold structure" style="width:100%;max-height:200px;object-fit:contain;display:block;">
+             </div>`
+          : '<div style="color:var(--mob-ink-3);font-size:13px;font-style:italic;">No structure available</div>'}
+      </div>
+      <div id="mob-structure-meta" style="margin-top:10px;"></div>
+      <div id="mob-struct-load-wrap"></div>
     </div>
 
     <!-- ── Mutants ── -->

--- a/web/js/views/genomes.js
+++ b/web/js/views/genomes.js
@@ -2838,15 +2838,19 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
         </div>
       </div>
       <div class="mob-tags-row" style="padding:8px 16px 0;flex-wrap:wrap;">
-        <span class="mob-tag" style="color:${color};border-color:${color};background:${hexToRgba(color,.1)};">${esc(strain)}</span>
         ${gene.functional_category ? `<span class="mob-tag" style="color:${catBadge.text};border-color:${catBadge.border};background:${catBadge.bg};">${esc(gene.functional_category)}</span>` : ''}
         ${gene.is_characterized ? `<span class="mob-tag" style="color:#1c8c7e;border-color:#1c8c7e;background:rgba(28,140,126,.08);">Characterized</span>` : ''}
         ${gene.is_t3_secreted   ? `<span class="mob-tag" style="color:#7c3aed;border-color:#7c3aed;background:rgba(124,58,237,.08);">T3 Secreted</span>` : ''}
         ${gene.is_dna_binding   ? `<span class="mob-tag" style="color:#b45309;border-color:#b45309;background:rgba(180,83,9,.08);">DNA Binding</span>` : ''}
       </div>
-      <div class="mob-meta-row" style="padding:10px 16px 0;">
+      <div class="mob-meta-row" style="padding:10px 16px 0;flex-wrap:wrap;gap:7px;">
         <a class="mob-copybtn" href="https://www.uniprot.org/uniprot/?query=${esc(gene.locus_tag)}" target="_blank" rel="noopener">UniProt ↗</a>
         <a class="mob-copybtn" href="https://www.ncbi.nlm.nih.gov/gene/?term=${esc(gene.locus_tag)}" target="_blank" rel="noopener">NCBI ↗</a>
+        <div id="mob-hero-extra-links" style="display:contents;"></div>
+        ${(gene.dna_sequence || gene.proteins) ? `<button id="mob-copy-seq-btn" class="mob-copybtn" style="cursor:pointer;background:var(--mob-bg-warm);">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+          Copy
+        </button>` : ''}
       </div>
     </div>
 
@@ -2857,7 +2861,7 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
         <div class="mob-kv"><div class="mob-k">Length</div><div class="mob-v sm">${gene.end_bp && gene.start_bp ? (gene.end_bp - gene.start_bp).toLocaleString() + ' bp' : '—'}</div></div>
         <div class="mob-kv"><div class="mob-k">Strand</div><div class="mob-v sm">${gene.strand === '+' || gene.strand === '1' ? '+ (sense)' : gene.strand ? '− (antisense)' : '—'}</div></div>
         <div class="mob-kv"><div class="mob-k">Position</div><div class="mob-v sm">${gene.start_bp ? gene.start_bp.toLocaleString() + '–' + (gene.end_bp ?? '?').toLocaleString() : '—'}</div></div>
-        <div class="mob-kv"><div class="mob-k">Organism</div><div class="mob-v sm">${esc(gene.strains?.common_name ?? _strain)}</div></div>
+        <div class="mob-kv" style="grid-column:1/-1;"><div class="mob-k">Organism</div><div class="mob-v sm">${STRAINS.find(s => s.id === (gene.strains?.common_name ?? _strain))?.label ?? esc(gene.strains?.common_name ?? _strain)}</div></div>
       </div>
     </div>
 
@@ -2878,15 +2882,15 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
     <!-- ── Protein ── -->
     <div class="mob-det-sec">
       <div class="mob-det-h">Protein</div>
+      <div id="mob-protein-product" style="display:none;margin-bottom:14px;">
+        <div class="mob-k" style="font-size:10.5px;letter-spacing:.06em;text-transform:uppercase;color:var(--mob-ink-3);margin-bottom:4px;">Product</div>
+        <div id="mob-protein-product-text" style="font-size:15px;font-weight:600;color:var(--mob-ink);line-height:1.45;"></div>
+      </div>
       <div class="mob-kv-grid" id="mob-protein-kv">
         <div class="mob-kv"><div class="mob-k">Mass</div><div class="mob-v sm">—</div></div>
         <div class="mob-kv"><div class="mob-k">Length</div><div class="mob-v sm">—</div></div>
         <div class="mob-kv"><div class="mob-k">TM domains</div><div class="mob-v sm">—</div></div>
         <div class="mob-kv"><div class="mob-k">Signal peptide</div><div class="mob-v sm">—</div></div>
-      </div>
-      <div id="mob-protein-product" style="display:none;margin-top:14px;">
-        <div class="mob-k" style="font-size:10.5px;letter-spacing:.06em;text-transform:uppercase;color:var(--mob-ink-3);margin-bottom:4px;">Product</div>
-        <div id="mob-protein-product-text" style="font-size:14px;color:var(--mob-ink);line-height:1.5;"></div>
       </div>
     </div>
 
@@ -2999,12 +3003,59 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
         <div class="mob-kv"><div class="mob-k">TM domains</div><div class="mob-v sm">${p.transmembrane_domains ?? '0'}</div></div>
         <div class="mob-kv"><div class="mob-k">Signal peptide</div><div class="mob-v sm">${p.signal_peptide ? 'Yes' : 'No'}</div></div>`;
     }
-    // Product (from gene.product, shown under kv grid)
+    // Product — move to top of protein section
     if (gene.product) {
       const prodWrap = scroll.querySelector('#mob-protein-product');
       const prodText = scroll.querySelector('#mob-protein-product-text');
       if (prodWrap && prodText) { prodText.textContent = gene.product; prodWrap.style.display = ''; }
     }
+
+    // ── Inject AFDB / PDB / Copy links into hero button bar ──
+    const extraLinks = scroll.querySelector('#mob-hero-extra-links');
+    if (extraLinks && p) {
+      const uniprotId = p.uniprot_id;
+      const crystalRow = p.alphafold_results?.find(r => r.af_version === 'crystal');
+      const pdbId = crystalRow?.top_homolog_pdb_id ?? null;
+      let linksHtml = '';
+      if (uniprotId) linksHtml += `<a class="mob-copybtn" href="https://alphafold.ebi.ac.uk/entry/${esc(uniprotId)}" target="_blank" rel="noopener">AFDB ↗</a>`;
+      if (pdbId)     linksHtml += `<a class="mob-copybtn" href="https://www.rcsb.org/structure/${esc(pdbId)}" target="_blank" rel="noopener">PDB ${esc(pdbId)} ↗</a>`;
+      extraLinks.innerHTML = linksHtml;
+    }
+
+    // ── Copy sequence button ──
+    scroll.querySelector('#mob-copy-seq-btn')?.addEventListener('click', (e) => {
+      e.stopPropagation();
+      // Build context popup
+      document.getElementById('mob-seq-popup')?.remove();
+      const popup = document.createElement('div');
+      popup.id = 'mob-seq-popup';
+      popup.className = 'mob-sheet-backdrop';
+      const hasDna = !!gene.dna_sequence;
+      const hasAa  = !!p?.aa_sequence;
+      popup.innerHTML = `
+        <div class="mob-sheet" onclick="event.stopPropagation()" style="padding-bottom:calc(env(safe-area-inset-bottom,14px)+12px);">
+          <div class="mob-sheet-handle"></div>
+          <div style="font-weight:800;font-size:17px;color:var(--mob-ink);padding:4px 4px 14px;">Copy Sequence</div>
+          ${hasDna ? `<div id="mob-cp-dna" style="display:flex;align-items:center;gap:13px;padding:13px 4px;border-top:.5px solid #f0f0f0;cursor:pointer;font-size:14.5px;font-weight:600;color:var(--mob-ink);">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+            DNA sequence (${(gene.dna_sequence.length / 1000).toFixed(1)} kb)
+          </div>` : ''}
+          ${hasAa ? `<div id="mob-cp-aa" style="display:flex;align-items:center;gap:13px;padding:13px 4px;border-top:.5px solid #f0f0f0;cursor:pointer;font-size:14.5px;font-weight:600;color:var(--mob-ink);">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+            Amino acid sequence (${p.aa_sequence.length} aa)
+          </div>` : ''}
+          ${!hasDna && !hasAa ? `<div style="padding:14px 4px;color:var(--mob-ink-3);font-size:14px;">No sequences available</div>` : ''}
+        </div>`;
+      const close = () => popup.remove();
+      popup.addEventListener('click', close);
+      const copyAndClose = (seq, label) => {
+        navigator.clipboard?.writeText(seq).catch(() => {});
+        close();
+      };
+      popup.querySelector('#mob-cp-dna')?.addEventListener('click', (ev) => { ev.stopPropagation(); copyAndClose(gene.dna_sequence, 'DNA'); });
+      popup.querySelector('#mob-cp-aa')?.addEventListener('click',  (ev) => { ev.stopPropagation(); copyAndClose(p.aa_sequence, 'AA'); });
+      document.body.appendChild(popup);
+    });
 
     // ── Structure ──
     _renderMobStructure(scroll, p);
@@ -3024,17 +3075,28 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
       if (!orthos.length) {
         orthoEl.innerHTML = '<div style="font-style:italic;color:var(--mob-ink-3);font-size:14px;">No orthologs recorded</div>';
       } else {
+        const STRAIN_ICONS = {
+          'CT-L2': '/design/icons_transparent/L2icon_transparent.png',
+          'CT-D':  '/design/icons_transparent/CTDicon_transparent.png',
+          'CM':    '/design/icons_transparent/CMicon_transparent.png',
+        };
         const rows = orthos.map(o => {
           const g = o.peer;
           if (!g) return '';
-          const col = g.strains?.color_hex ?? '#9ca3af';
-          const strainName = g.strains?.common_name ?? '?';
-          const label = g.gene_name ? `${esc(g.locus_tag)} <span style="color:var(--mob-ink-3);">${esc(g.gene_name)}</span>` : `<span style="color:var(--mob-ink-3);">${esc(g.locus_tag)}</span>`;
-          return `<div class="mob-tg-row" data-ortho-id="${g.id}" style="cursor:pointer;border-radius:10px;border:.5px solid var(--mob-line);margin-bottom:7px;">
-            <div style="width:4px;align-self:stretch;border-radius:3px;background:${col};flex-shrink:0;"></div>
-            <div style="flex:1;min-width:0;padding:2px 0;">
-              <div style="font-size:10.5px;font-weight:700;color:var(--mob-ink-3);letter-spacing:.04em;">${esc(strainName)}</div>
-              <div style="font-size:14px;font-weight:700;color:var(--mob-ink);margin-top:1px;">${label}</div>
+          const strainName  = g.strains?.common_name ?? '?';
+          const strainIcon  = STRAIN_ICONS[strainName];
+          // Bold = locus_tag + gene_name (if any) in one line — no redundant secondary tag
+          const displayText = g.gene_name
+            ? `${esc(g.locus_tag)} <span style="color:var(--mob-ink-3);font-weight:400;">${esc(g.gene_name)}</span>`
+            : esc(g.locus_tag);
+          const iconEl = strainIcon
+            ? `<img src="${strainIcon}" alt="${strainName}" style="width:32px;height:32px;object-fit:contain;flex-shrink:0;">`
+            : `<div style="width:32px;height:32px;border-radius:50%;background:#f0f2f0;flex-shrink:0;"></div>`;
+          return `<div class="mob-tg-row" data-ortho-id="${g.id}" style="cursor:pointer;border-radius:10px;border:.5px solid var(--mob-line);margin-bottom:7px;padding:10px 12px;">
+            ${iconEl}
+            <div style="flex:1;min-width:0;">
+              <div style="font-size:10.5px;font-weight:700;color:var(--mob-ink-3);letter-spacing:.03em;margin-bottom:2px;">${esc(strainName)}</div>
+              <div style="font-size:14px;font-weight:700;color:var(--mob-ink);">${displayText}</div>
             </div>
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#c8cec9" stroke-width="2.2" stroke-linecap="round"><polyline points="9 18 15 12 9 6"/></svg>
           </div>`;
@@ -3059,28 +3121,29 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
       if (!mutants.length) {
         mutEl.innerHTML = '<div style="font-style:italic;color:var(--mob-ink-3);font-size:14px;">No mutants target this gene</div>';
       } else {
-        const TYPE_ACCENT = { transposon:'#059669', deletion:'#dc2626', chimera:'#7c3aed', chemical:'#2563eb', intron:'#ca8a04', recombination:'#db2777' };
-        // Update header to show count
+        const TYPE_ACCENT  = { transposon:'#059669', deletion:'#dc2626', chimera:'#7c3aed', chemical:'#2563eb', intron:'#ca8a04', recombination:'#db2777' };
+        const TYPE_LABELS2 = { transposon:'Transposon', deletion:'Deletion', chimera:'Chimera', chemical:'Chemical', intron:'Targetron', recombination:'Recombination' };
         const mutHead = scroll.querySelector('#mob-mutants-head');
         if (mutHead) mutHead.textContent = `Mutants (${mutants.length})`;
 
         const rows = mutants.map((m, i) => {
-          const isChimera = m.mutation_type === 'chimera';
-          // Chimeras and recombinants: use mutant_id (RC###) as primary
+          const isChimera = m.mutation_type === 'chimera' || m.mutation_type === 'recombination';
           const primary   = isChimera ? m.mutant_id : (m.name || m.mutant_id);
-          const secondary = isChimera ? '' : (m.name ? m.mutant_id : '');
-          const col = TYPE_ACCENT[m.mutation_type] ?? '#8b958f';
-          const pubBadge = m.is_published
-            ? `<span style="font-size:10px;font-weight:700;padding:2px 7px;border-radius:4px;background:rgba(5,150,105,.09);color:#059669;border:1px solid rgba(5,150,105,.2);">Published</span>`
-            : `<span style="font-size:10px;font-weight:700;padding:2px 7px;border-radius:4px;background:rgba(180,83,9,.08);color:#b45309;border:1px solid rgba(180,83,9,.2);">Lab</span>`;
-          const divider = i < mutants.length - 1 ? `border-bottom:1px solid var(--mob-line);` : '';
+          const secondary = isChimera ? (m.name || '') : (m.name ? m.mutant_id : '');
+          const col       = TYPE_ACCENT[m.mutation_type] ?? '#8b958f';
+          const typeLabel = TYPE_LABELS2[m.mutation_type] ?? (m.mutation_type ?? '');
+          const typePill  = `<span style="font-size:10px;font-weight:700;padding:2px 8px;border-radius:4px;background:${col}14;color:${col};border:1px solid ${col}33;">${typeLabel}</span>`;
+          const lockIcon  = !m.is_published
+            ? `<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--mob-ink-3)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0;"><rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>` : '';
+          const divider   = i < mutants.length - 1 ? 'border-bottom:1px solid var(--mob-line);' : '';
           return `<div data-mut-id="${m.id}" style="display:flex;align-items:center;gap:10px;padding:10px 0;cursor:pointer;${divider}">
-            <div style="width:4px;height:36px;border-radius:3px;background:${col};flex-shrink:0;"></div>
+            <div style="width:4px;min-height:38px;border-radius:3px;background:${col};flex-shrink:0;align-self:stretch;"></div>
             <div style="flex:1;min-width:0;">
-              <div style="font-family:var(--mob-mono);font-size:14px;font-weight:700;color:var(--mob-ink);">${esc(primary)}${secondary ? ` <span style="font-weight:400;color:var(--mob-ink-3);font-size:12px;">${esc(secondary)}</span>` : ''}</div>
-              <div style="font-size:12px;color:var(--mob-ink-3);margin-top:2px;">${esc(m.collection ?? '')} · ${esc(m.mutation_type ?? '')}</div>
+              <div style="font-size:14.5px;font-weight:700;color:var(--mob-ink);">${esc(primary)}</div>
+              ${secondary ? `<div style="font-size:12px;color:var(--mob-ink-3);margin-top:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${esc(secondary)}</div>` : ''}
+              <div style="margin-top:5px;">${typePill}</div>
             </div>
-            ${pubBadge}
+            ${lockIcon}
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#c8cec9" stroke-width="2.2" stroke-linecap="round"><polyline points="9 18 15 12 9 6"/></svg>
           </div>`;
         }).join('');
@@ -3446,7 +3509,7 @@ async function _buildMobGenomicContext(gene, inner) {
     const minusArrow = !isPlus ? `<div class="mob-ctx-arrow minus" style="width:${width};"><div class="body" style="background:${col};opacity:${opacity};"></div></div>` : '';
 
     return `
-      <div class="mob-ctx-col${isFocal ? ' focal' : ''}" ${isFocal ? 'data-focal="1"' : ''}>
+      <div class="mob-ctx-col${isFocal ? ' focal' : ''}" ${isFocal ? 'data-focal="1"' : ''} data-gene-id="${g.id}">
         <div class="mob-ctx-lab">${isPlus ? `<span class="sym">${sym}</span>` : ''}</div>
         <div class="mob-ctx-arrow-slot plus">${plusArrow}</div>
         <div class="mob-ctx-center"></div>
@@ -3466,7 +3529,6 @@ async function _buildMobGenomicContext(gene, inner) {
       </div>
       <div class="mob-ctx-fade l"></div>
       <div class="mob-ctx-fade r"></div>
-      <div class="mob-ctx-hint" id="mob-ctx-hint">↔ swipe</div>
     </div>`;
 
   const scr   = inner.querySelector('#mob-ctx-scr');
@@ -3477,10 +3539,22 @@ async function _buildMobGenomicContext(gene, inner) {
     };
     requestAnimationFrame(doCenter);
     setTimeout(doCenter, 140);
-
-    const hint = inner.querySelector('#mob-ctx-hint');
-    if (hint) scr.addEventListener('scroll', () => { hint.style.opacity = '0'; }, { once: true, passive: true });
   }
+
+  // Make non-focal gene columns tappable — navigate to that gene
+  inner.querySelectorAll('.mob-ctx-col:not([data-focal])').forEach(col => {
+    const geneId = col.dataset.geneId;
+    if (!geneId) return;
+    col.style.cursor = 'pointer';
+    col.addEventListener('click', () => {
+      const cached = _geneCache.get(String(geneId));
+      if (cached) { showGeneDetailMobile(cached, _container); return; }
+      sb.from('genes')
+        .select('id,strain_id,locus_tag,gene_name,gene_symbol,product,sort_index,start_bp,end_bp,strand,functional_category,is_characterized,is_membrane_protein,is_hypothetical,is_dna_binding,is_t3_secreted,expression_pattern,updated_at,updated_by,strains!inner(common_name,color_hex),proteins(alphafold_results(thumbnail_path))')
+        .eq('id', geneId).single()
+        .then(({ data }) => { if (data) { _geneCache.set(String(data.id), data); showGeneDetailMobile(data, _container); } });
+    });
+  });
 }
 
 const CATEGORY_OPTIONS = Object.keys(CATEGORY_COLORS);
@@ -3526,12 +3600,20 @@ async function openGeneEditModal(gene, proteinArg, detail, container) {
     pdbRows = data ?? [];
   }
 
+  const isMob = isMobileViewport();
   const overlay = document.createElement('div');
   overlay.id = 'gene-edit-overlay';
-  overlay.style.cssText = [
-    'position:fixed;inset:0;background:rgba(0,0,0,0.5);z-index:2000;',
-    'display:flex;align-items:center;justify-content:center;padding:16px;',
-  ].join('');
+
+  if (isMob) {
+    // Mobile: pull-up sheet
+    overlay.className = 'mob-sheet-backdrop';
+    overlay.style.cssText = 'z-index:2000;';
+  } else {
+    overlay.style.cssText = [
+      'position:fixed;inset:0;background:rgba(0,0,0,0.5);z-index:2000;',
+      'display:flex;align-items:center;justify-content:center;padding:16px;',
+    ].join('');
+  }
 
   function closeModal() {
     overlay.remove();
@@ -3547,7 +3629,17 @@ async function openGeneEditModal(gene, proteinArg, detail, container) {
     if (e.target === overlay) closeModal();
   });
 
-  overlay.innerHTML = buildModalHtml(gene, protein, pdbRows);
+  if (isMob) {
+    // Wrap the modal form in a mob-sheet pull-up
+    const sheet = document.createElement('div');
+    sheet.className = 'mob-sheet';
+    sheet.style.cssText = 'max-height:88vh;overflow-y:auto;padding:0;';
+    sheet.addEventListener('click', e => e.stopPropagation());
+    sheet.innerHTML = `<div class="mob-sheet-handle"></div>` + buildModalHtml(gene, protein, pdbRows);
+    overlay.appendChild(sheet);
+  } else {
+    overlay.innerHTML = buildModalHtml(gene, protein, pdbRows);
+  }
   document.body.appendChild(overlay);
 
   overlay._onEsc = onEsc;

--- a/web/js/views/genomes.js
+++ b/web/js/views/genomes.js
@@ -3,9 +3,9 @@ import { sb, state, toggleFavoriteDB } from '../client.js?v=82';
 import { isMobileViewport, onMobScroll, pushMobileDetail } from '../app.js?v=82';
 
 const STRAINS = [
-  { id: 'CT-L2', label: 'CT L2/434', icon: '/design/icons_transparent/L2icon_transparent.png' },
-  { id: 'CT-D',  label: 'CT D/UW-3', icon: '/design/icons_transparent/CTDicon_transparent.png' },
-  { id: 'CM',    label: 'CM',         icon: '/design/icons_transparent/CMicon_transparent.png' },
+  { id: 'CT-L2', label: '<i>C. trachomatis</i> L2/434', icon: '/design/icons_transparent/L2icon_transparent.png' },
+  { id: 'CT-D',  label: '<i>C. trachomatis</i> D/UW-3', icon: '/design/icons_transparent/CTDicon_transparent.png' },
+  { id: 'CM',    label: '<i>C. muridarum</i> Nigg',      icon: '/design/icons_transparent/CMicon_transparent.png' },
 ];
 
 const ORGANISM_FULL = {
@@ -491,7 +491,7 @@ function _showMobStrainSheet(container) {
           <img src="${s.icon}" alt="${s.id}" style="width:38px;height:38px;object-fit:contain;">
           <div style="flex:1;">
             <div style="font-weight:800;font-size:16px;color:${s.id === 'CT-L2' ? '#2f9e6e' : s.id === 'CT-D' ? '#b14a93' : '#3f7fc4'};">${s.id}</div>
-            <div style="font-size:13px;font-style:italic;color:var(--mob-ink-2);">${s.label}</div>
+            <div style="font-size:13px;color:var(--mob-ink-2);">${s.label}</div>
           </div>
           ${s.id === _strain ? '<span style="color:var(--mob-green);font-weight:800;">✓</span>' : ''}
         </div>`).join('')}
@@ -2860,7 +2860,7 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
     <!-- ── Orthologs ── -->
     <div class="mob-card">
       <div class="mob-card-h">Orthologs</div>
-      <div id="mob-orthologs-inner" style="margin-top:10px;color:var(--mob-ink-3);font-size:13px;font-style:italic;">Loading…</div>
+      <div id="mob-orthologs-inner" style="margin-top:10px;color:var(--mob-ink-3);font-size:13px;">Loading…</div>
     </div>
 
     <!-- ── Genomic Context ── -->
@@ -2889,19 +2889,19 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
     <!-- ── Cell Localization ── -->
     <div class="mob-card">
       <div class="mob-card-h" id="mob-loc-head">Cell Localization</div>
-      <div id="mob-loc-inner" style="margin-top:10px;color:var(--mob-ink-3);font-size:13px;font-style:italic;">Loading…</div>
+      <div id="mob-loc-inner" style="margin-top:10px;color:var(--mob-ink-3);font-size:13px;">Loading…</div>
     </div>
 
     <!-- ── Transcriptomics ── -->
     <div class="mob-card">
       <div class="mob-card-h">Transcriptomics</div>
-      <div id="mob-transcriptomics-inner" style="margin-top:10px;color:var(--mob-ink-3);font-size:13px;font-style:italic;">Loading…</div>
+      <div id="mob-transcriptomics-inner" style="margin-top:10px;color:var(--mob-ink-3);font-size:13px;">Loading…</div>
     </div>
 
     <!-- ── EB / RB Proteomics ── -->
     <div class="mob-card">
       <div class="mob-card-h">EB / RB Proteomics</div>
-      <div id="mob-proteomics-inner" style="margin-top:12px;font-style:italic;color:var(--mob-ink-3);font-size:14px;">Loading…</div>
+      <div id="mob-proteomics-inner" style="margin-top:12px;color:var(--mob-ink-3);font-size:14px;">Loading…</div>
     </div>
 
     <!-- ── Structure ── -->
@@ -2912,7 +2912,7 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
           ? `<div id="mob-struct-thumb-wrap" style="position:relative;border-radius:12px;overflow:hidden;border:.5px solid var(--mob-line);">
                <img id="mob-struct-thumb" src="${esc(thumb)}" alt="AlphaFold structure" style="width:100%;max-height:200px;object-fit:contain;display:block;">
              </div>`
-          : '<div style="color:var(--mob-ink-3);font-size:13px;font-style:italic;">No structure available</div>'}
+          : '<div style="color:var(--mob-ink-3);font-size:13px;">No structure available</div>'}
       </div>
       <div id="mob-structure-meta" style="margin-top:10px;"></div>
       <div id="mob-struct-load-wrap"></div>
@@ -2921,7 +2921,7 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
     <!-- ── Mutants ── -->
     <div class="mob-card">
       <div class="mob-card-h">Mutants</div>
-      <div id="mob-mutants-inner" style="margin-top:10px;color:var(--mob-ink-3);font-size:13px;font-style:italic;">Loading…</div>
+      <div id="mob-mutants-inner" style="margin-top:10px;color:var(--mob-ink-3);font-size:13px;">Loading…</div>
     </div>
 
     <div class="mob-pad-bottom"></div>`;
@@ -2948,9 +2948,7 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
   // ── Async: fetch all panel data in one round trip ──
   Promise.all([
     sb.from('proteins')
-      .select('mass_kd,length_aa,transmembrane_domains,signal_peptide,eb_enriched,rb_enriched,' +
-              'uniprot_id,localization,localization_source,subcellular_location_sl,subcellular_location_go,' +
-              'alphafold_results(*)')
+      .select('*,alphafold_results(*)')
       .eq('gene_id', gene.id)
       .maybeSingle(),
     sb.from('expression_data').select('*').eq('gene_id', gene.id),

--- a/web/js/views/genomes.js
+++ b/web/js/views/genomes.js
@@ -2762,11 +2762,11 @@ function showGeneDetailMobile(gene, _container) {
 }
 
 function _renderGeneDetailMobileHTML(gene, scroll) {
-  const color      = CATEGORY_COLORS[gene.functional_category] ?? CATEGORY_COLOR_DEFAULT;
-  const catBadge   = CATEGORY_BADGE[gene.functional_category] ?? { bg:'#f9fafb', text:'#6b7280', border:'#e5e7eb' };
-  const isFav      = state.favorites.genes.has(String(gene.id));
-  const thumb      = gene.proteins?.alphafold_results?.find(r => r.thumbnail_path)?.thumbnail_path;
-  const strain     = gene.strains?.common_name ?? _strain;
+  const color       = CATEGORY_COLORS[gene.functional_category] ?? CATEGORY_COLOR_DEFAULT;
+  const catBadge    = CATEGORY_BADGE[gene.functional_category] ?? { bg:'#f9fafb', text:'#6b7280', border:'#e5e7eb' };
+  const isFav       = state.favorites.genes.has(String(gene.id));
+  const thumb       = gene.proteins?.alphafold_results?.find(r => r.thumbnail_path)?.thumbnail_path;
+  const strain      = gene.strains?.common_name ?? _strain;
   const displayName = gene.gene_name || gene.gene_symbol || gene.locus_tag;
   const locusShow   = gene.gene_name ? gene.locus_tag : '';
   const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
@@ -2777,9 +2777,16 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
     return `rgba(${r},${g},${b},${a})`;
   };
 
+  const productPill = gene.product
+    ? `<span class="mob-tag" style="color:#4a5650;border-color:#c8d0cb;background:#f0f2f0;font-weight:600;text-transform:none;font-size:10.5px;max-width:260px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${esc(gene.product.length > 55 ? gene.product.slice(0,52) + '…' : gene.product)}</span>`
+    : '';
+
   scroll.innerHTML = `
-    <div style="background:${hexToRgba(color,.08)};border-bottom:3px solid ${color};padding-bottom:12px;">
-      <div class="mob-d-head">
+    <!-- ── Header: gradient bleed ── -->
+    <div style="margin-top:calc(-1 * var(--mob-nav-h));padding-top:calc(var(--mob-nav-h) + 10px);
+                background:linear-gradient(180deg,${hexToRgba(color,.20)} 0%,${hexToRgba(color,.04)} 100%);
+                border-bottom:2px solid ${hexToRgba(color,.35)};padding-bottom:14px;">
+      <div class="mob-d-head" style="padding:0 12px 0 16px;">
         <div class="mob-d-thumb" style="background:${hexToRgba(color,.15)};">
           ${thumb
             ? `<img src="${esc(thumb)}" alt="structure" loading="lazy">`
@@ -2789,42 +2796,47 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
           <div class="mob-d-title">${esc(displayName)}</div>
           ${locusShow ? `<span class="mob-d-loc">${esc(locusShow)}</span>` : ''}
         </div>
-        <div class="mob-d-actions">
-          <button class="mob-gbtn mob-fav-btn${isFav ? ' saved-on' : ''}" data-id="${gene.id}" aria-label="Save gene">
-            <svg width="19" height="19" viewBox="0 0 24 24" fill="${isFav ? '#e8b400' : 'none'}" stroke="${isFav ? '#e8b400' : 'currentColor'}" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+        <div class="mob-d-actions" style="flex-shrink:0;">
+          <button class="mob-fav-btn${isFav ? ' saved-on' : ''}" data-id="${gene.id}" aria-label="Save gene"
+            style="background:none;border:none;padding:8px 4px;cursor:pointer;color:${isFav ? '#e8b400' : 'var(--mob-ink-3)'};">
+            <svg width="21" height="21" viewBox="0 0 24 24" fill="${isFav ? '#e8b400' : 'none'}" stroke="${isFav ? '#e8b400' : 'currentColor'}" stroke-width="2"><path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"/></svg>
           </button>
         </div>
       </div>
-      <div class="mob-tags-row" style="padding:0 20px 0;">
+      <div class="mob-tags-row" style="padding:8px 16px 0;flex-wrap:wrap;">
         <span class="mob-tag" style="color:${color};border-color:${color};background:${hexToRgba(color,.1)};">${esc(strain)}</span>
         ${gene.functional_category ? `<span class="mob-tag" style="color:${catBadge.text};border-color:${catBadge.border};background:${catBadge.bg};">${esc(gene.functional_category)}</span>` : ''}
         ${gene.is_characterized ? `<span class="mob-tag" style="color:#1c8c7e;border-color:#1c8c7e;background:rgba(28,140,126,.08);">Characterized</span>` : ''}
         ${gene.is_t3_secreted   ? `<span class="mob-tag" style="color:#7c3aed;border-color:#7c3aed;background:rgba(124,58,237,.08);">T3 Secreted</span>` : ''}
         ${gene.is_dna_binding   ? `<span class="mob-tag" style="color:#b45309;border-color:#b45309;background:rgba(180,83,9,.08);">DNA Binding</span>` : ''}
+        ${productPill}
       </div>
-      <div class="mob-meta-row" style="padding:8px 20px 0;">
+      <div class="mob-meta-row" style="padding:10px 16px 0;">
         <a class="mob-copybtn" href="https://www.uniprot.org/uniprot/?query=${esc(gene.locus_tag)}" target="_blank" rel="noopener">UniProt ↗</a>
         <a class="mob-copybtn" href="https://www.ncbi.nlm.nih.gov/gene/?term=${esc(gene.locus_tag)}" target="_blank" rel="noopener">NCBI ↗</a>
       </div>
     </div>
 
+    <!-- ── Gene Info ── -->
     <div class="mob-card">
       <div class="mob-card-h">Gene Info</div>
       <div class="mob-kv-grid">
         <div class="mob-kv"><div class="mob-k">Length</div><div class="mob-v sm">${gene.end_bp && gene.start_bp ? (gene.end_bp - gene.start_bp).toLocaleString() + ' bp' : '—'}</div></div>
         <div class="mob-kv"><div class="mob-k">Strand</div><div class="mob-v sm">${gene.strand === '+' || gene.strand === '1' ? '+ (sense)' : gene.strand ? '− (antisense)' : '—'}</div></div>
         <div class="mob-kv"><div class="mob-k">Position</div><div class="mob-v sm">${gene.start_bp ? gene.start_bp.toLocaleString() + '–' + (gene.end_bp ?? '?').toLocaleString() : '—'}</div></div>
-        <div class="mob-kv"><div class="mob-k">Organism</div><div class="mob-v sm" style="font-style:italic;">${esc(gene.strains?.common_name ?? _strain)}</div></div>
+        <div class="mob-kv"><div class="mob-k">Organism</div><div class="mob-v sm">${esc(gene.strains?.common_name ?? _strain)}</div></div>
       </div>
     </div>
 
+    <!-- ── Genomic Context ── -->
     <div class="mob-card" id="mob-ctx-card">
-      <div class="mob-card-h">Genomic Context <span style="color:var(--mob-ink-3);font-weight:400;">${esc(strain)} chromosome</span></div>
+      <div class="mob-card-h">Genomic Context <span style="color:var(--mob-ink-3);font-weight:400;">${esc(strain)}</span></div>
       <div id="mob-ctx-inner" style="margin-top:8px;min-height:80px;display:flex;align-items:center;justify-content:center;">
         <span style="color:var(--mob-ink-3);font-size:13px;">Loading…</span>
       </div>
     </div>
 
+    <!-- ── Protein ── -->
     <div class="mob-card">
       <div class="mob-card-h">Protein</div>
       <div class="mob-kv-grid" id="mob-protein-kv">
@@ -2833,84 +2845,343 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
         <div class="mob-kv"><div class="mob-k">TM domains</div><div class="mob-v sm">—</div></div>
         <div class="mob-kv"><div class="mob-k">Signal peptide</div><div class="mob-v sm">—</div></div>
       </div>
+      <div id="mob-protein-product" style="display:none;margin-top:12px;">
+        <div class="mob-k" style="font-family:var(--mob-mono);font-size:10.5px;letter-spacing:.08em;text-transform:uppercase;color:var(--mob-ink-3);margin-bottom:5px;">Product</div>
+        <div id="mob-protein-product-text" style="font-size:14px;color:var(--mob-ink);line-height:1.5;"></div>
+      </div>
     </div>
 
+    <!-- ── Structure ── -->
     <div class="mob-card">
       <div class="mob-card-h">Structure</div>
-      <div id="mob-structure-inner" style="margin-top:12px;text-align:center;color:var(--mob-ink-3);font-size:13px;">
+      <div id="mob-structure-inner" style="margin-top:12px;">
         ${thumb
-          ? `<img src="${esc(thumb)}" alt="AlphaFold structure" style="width:100%;max-height:180px;object-fit:contain;border-radius:12px;border:.5px solid var(--mob-line);">`
-          : 'No structure available'}
+          ? `<div id="mob-struct-thumb-wrap" style="position:relative;border-radius:12px;overflow:hidden;border:.5px solid var(--mob-line);">
+               <img id="mob-struct-thumb" src="${esc(thumb)}" alt="AlphaFold structure" style="width:100%;max-height:200px;object-fit:contain;display:block;">
+             </div>`
+          : '<div style="color:var(--mob-ink-3);font-size:13px;font-style:italic;">No structure available</div>'}
       </div>
+      <div id="mob-structure-meta" style="margin-top:10px;"></div>
+      <div id="mob-struct-load-wrap"></div>
     </div>
 
+    <!-- ── Transcriptomics ── -->
     <div class="mob-card">
       <div class="mob-card-h">Transcriptomics</div>
-      <div style="margin-top:10px;">
-        ${gene.expression_pattern
-          ? `<div style="display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:999px;background:#eef2ef;font-weight:800;font-size:13px;color:var(--mob-ink);">
-               <span style="width:8px;height:8px;border-radius:50%;background:var(--mob-green);"></span>
-               ${esc(gene.expression_pattern)}
-             </div>`
-          : `<div style="font-style:italic;color:var(--mob-ink-3);font-size:14px;">No expression data</div>`}
-      </div>
+      <div id="mob-transcriptomics-inner" style="margin-top:10px;color:var(--mob-ink-3);font-size:13px;font-style:italic;">Loading…</div>
     </div>
 
+    <!-- ── EB / RB Proteomics ── -->
     <div class="mob-card">
       <div class="mob-card-h">EB / RB Proteomics</div>
       <div id="mob-proteomics-inner" style="margin-top:12px;font-style:italic;color:var(--mob-ink-3);font-size:14px;">Loading…</div>
     </div>
 
+    <!-- ── Cell Localization ── -->
+    <div class="mob-card">
+      <div class="mob-card-h" id="mob-loc-head">Cell Localization</div>
+      <div id="mob-loc-inner" style="margin-top:10px;color:var(--mob-ink-3);font-size:13px;font-style:italic;">Loading…</div>
+    </div>
+
+    <!-- ── Orthologs ── -->
+    <div class="mob-card">
+      <div class="mob-card-h">Orthologs</div>
+      <div id="mob-orthologs-inner" style="margin-top:10px;color:var(--mob-ink-3);font-size:13px;font-style:italic;">Loading…</div>
+    </div>
+
+    <!-- ── Mutants ── -->
+    <div class="mob-card">
+      <div class="mob-card-h">Mutants</div>
+      <div id="mob-mutants-inner" style="margin-top:10px;color:var(--mob-ink-3);font-size:13px;font-style:italic;">Loading…</div>
+    </div>
+
     <div class="mob-pad-bottom"></div>`;
 
+  // ── Favorite toggle ──
   scroll.querySelector('.mob-fav-btn')?.addEventListener('click', async (e) => {
     e.stopPropagation();
     const btn = e.currentTarget;
     await toggleFavoriteDB('gene', gene.id);
     const nowFav = state.favorites.genes.has(String(gene.id));
     btn.classList.toggle('saved-on', nowFav);
+    btn.style.color = nowFav ? '#e8b400' : 'var(--mob-ink-3)';
     const svg = btn.querySelector('svg');
     if (svg) { svg.setAttribute('fill', nowFav ? '#e8b400' : 'none'); svg.setAttribute('stroke', nowFav ? '#e8b400' : 'currentColor'); }
     if (nowFav) btn.classList.add('mob-star-pop');
     btn.addEventListener('animationend', () => btn.classList.remove('mob-star-pop'), { once: true });
   });
 
-  if (gene.id) {
-    sb.from('proteins')
-      .select('mass_kd,length_aa,transmembrane_domains,signal_peptide')
-      .eq('gene_id', gene.id)
-      .maybeSingle()
-      .then(({ data: p }) => {
-        const kvEl = scroll.querySelector('#mob-protein-kv');
-        if (kvEl && p) {
-          kvEl.innerHTML = `
-            <div class="mob-kv"><div class="mob-k">Mass</div><div class="mob-v sm">${p.mass_kd ? p.mass_kd.toFixed(1) + ' kDa' : '—'}</div></div>
-            <div class="mob-kv"><div class="mob-k">Length</div><div class="mob-v sm">${p.length_aa ? p.length_aa.toLocaleString() + ' aa' : '—'}</div></div>
-            <div class="mob-kv"><div class="mob-k">TM domains</div><div class="mob-v sm">${p.transmembrane_domains ?? '0'}</div></div>
-            <div class="mob-kv"><div class="mob-k">Signal peptide</div><div class="mob-v sm">${p.signal_peptide ? 'Yes' : 'No'}</div></div>`;
-        }
-      });
+  // ── Genomic context (fast, separate) ──
+  _buildMobGenomicContext(gene, scroll.querySelector('#mob-ctx-inner'));
 
+  if (!gene.id) return;
+
+  // ── Async: fetch all panel data in one round trip ──
+  Promise.all([
     sb.from('proteins')
-      .select('eb_enriched,rb_enriched')
+      .select('mass_kd,length_aa,transmembrane_domains,signal_peptide,eb_enriched,rb_enriched,' +
+              'uniprot_id,localization,localization_source,subcellular_location_sl,subcellular_location_go,' +
+              'alphafold_results(*)')
       .eq('gene_id', gene.id)
-      .maybeSingle()
-      .then(({ data: p }) => {
-        const el = scroll.querySelector('#mob-proteomics-inner');
-        if (!el) return;
-        if (!p || (p.eb_enriched == null && p.rb_enriched == null)) {
-          el.textContent = 'No proteomic data available';
-        } else {
-          el.innerHTML = `
-            <div class="mob-kv-grid">
-              <div class="mob-kv"><div class="mob-k">EB enriched</div><div class="mob-v sm">${p.eb_enriched ? 'Yes' : 'No'}</div></div>
-              <div class="mob-kv"><div class="mob-k">RB enriched</div><div class="mob-v sm">${p.rb_enriched ? 'Yes' : 'No'}</div></div>
-            </div>`;
-        }
+      .maybeSingle(),
+    sb.from('expression_data').select('*').eq('gene_id', gene.id),
+    sb.from('orthologs')
+      .select('id,gene_b:genes!gene_id_b(id,locus_tag,gene_name,strains(common_name,color_hex))')
+      .eq('gene_id_a', gene.id),
+    sb.from('orthologs')
+      .select('id,gene_a:genes!gene_id_a(id,locus_tag,gene_name,strains(common_name,color_hex))')
+      .eq('gene_id_b', gene.id),
+    sb.from('mutants')
+      .select('id,mutant_id,name,mutation_type,is_published,collection')
+      .contains('target_gene_ids', [gene.id])
+      .order('mutant_id'),
+  ]).then(([protRes, exprRes, orthoFwdRes, orthoRevRes, mutRes]) => {
+    if (!scroll.isConnected) return; // navigated away
+
+    const p       = protRes.data;
+    const exprs   = exprRes.data   ?? [];
+    const mutants = mutRes.data    ?? [];
+
+    // Merge orthologs, deduplicate
+    const fwd = (orthoFwdRes.data ?? []).map(o => ({ id: o.id, peer: o.gene_b }));
+    const rev = (orthoRevRes.data ?? []).map(o => ({ id: o.id, peer: o.gene_a }));
+    const seen = new Set(fwd.map(o => o.id));
+    const orthos = [...fwd, ...rev.filter(o => !seen.has(o.id))];
+
+    // ── Protein kv ──
+    const kvEl = scroll.querySelector('#mob-protein-kv');
+    if (kvEl && p) {
+      kvEl.innerHTML = `
+        <div class="mob-kv"><div class="mob-k">Mass</div><div class="mob-v sm">${p.mass_kd ? p.mass_kd.toFixed(1) + ' kDa' : '—'}</div></div>
+        <div class="mob-kv"><div class="mob-k">Length</div><div class="mob-v sm">${p.length_aa ? p.length_aa.toLocaleString() + ' aa' : '—'}</div></div>
+        <div class="mob-kv"><div class="mob-k">TM domains</div><div class="mob-v sm">${p.transmembrane_domains ?? '0'}</div></div>
+        <div class="mob-kv"><div class="mob-k">Signal peptide</div><div class="mob-v sm">${p.signal_peptide ? 'Yes' : 'No'}</div></div>`;
+    }
+    // Product (from gene.product, shown under kv grid)
+    if (gene.product) {
+      const prodWrap = scroll.querySelector('#mob-protein-product');
+      const prodText = scroll.querySelector('#mob-protein-product-text');
+      if (prodWrap && prodText) { prodText.textContent = gene.product; prodWrap.style.display = ''; }
+    }
+
+    // ── Structure ──
+    const afRows  = p?.alphafold_results ?? [];
+    const af3     = afRows.find(r => r.af_version === 'AF3');
+    const bestAf  = af3 ?? afRows.find(r => r.af_version === 'AF2' || r.af_version === 'AFDB') ?? afRows[0];
+    const mmcif   = bestAf?.mmcif_path ?? null;
+    const homolog = bestAf?.top_homolog_description ?? null;
+    const pdbId   = bestAf?.top_homolog_pdb_id ?? null;
+    const inferFn = bestAf?.inferred_function ?? null;
+
+    const metaEl = scroll.querySelector('#mob-structure-meta');
+    if (metaEl && (homolog || inferFn)) {
+      metaEl.innerHTML = `
+        ${homolog ? `<div style="font-size:13px;font-weight:600;color:var(--mob-ink);margin-bottom:2px;">${esc(homolog)}${pdbId ? ` <span style="font-family:var(--mob-mono);font-size:11px;color:var(--mob-ink-3);">${esc(pdbId)}</span>` : ''}</div>` : ''}
+        ${inferFn ? `<div style="font-size:12.5px;color:#444;background:#f0fdf4;border-radius:8px;padding:8px 10px;border-left:3px solid #16a34a;line-height:1.5;margin-top:6px;"><strong style="color:#1a6b4a;">Inferred:</strong> ${esc(inferFn)}</div>` : ''}`;
+    }
+    const loadWrap = scroll.querySelector('#mob-struct-load-wrap');
+    if (loadWrap && mmcif) {
+      loadWrap.innerHTML = `<button id="mob-struct-3d-btn" style="margin-top:12px;width:100%;padding:10px;border-radius:10px;border:1.5px solid var(--mob-line);background:var(--mob-bg-warm);font-family:var(--mob-sans);font-size:14px;font-weight:700;color:var(--mob-green-ink);cursor:pointer;display:flex;align-items:center;justify-content:center;gap:8px;">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/></svg>
+        View in 3D
+      </button>`;
+      loadWrap.querySelector('#mob-struct-3d-btn').addEventListener('click', async (e) => {
+        const btn = e.currentTarget;
+        btn.textContent = 'Loading viewer…';
+        btn.disabled = true;
+        const container = document.createElement('div');
+        container.style.cssText = 'position:relative;width:100%;height:320px;border-radius:12px;overflow:hidden;margin-top:12px;background:#111;';
+        loadWrap.appendChild(container);
+        await loadMolstar(container, mmcif);
+        btn.remove();
       });
+    }
+
+    // ── Transcriptomics ──
+    _renderMobTranscriptomics(scroll.querySelector('#mob-transcriptomics-inner'), gene, exprs);
+
+    // ── EB / RB Proteomics ──
+    const protEl = scroll.querySelector('#mob-proteomics-inner');
+    if (protEl) {
+      if (!p || (p.eb_enriched == null && p.rb_enriched == null)) {
+        protEl.textContent = 'No proteomic data available';
+      } else {
+        protEl.innerHTML = `
+          <div class="mob-kv-grid">
+            <div class="mob-kv"><div class="mob-k">EB enriched</div><div class="mob-v sm">${p.eb_enriched ? 'Yes' : 'No'}</div></div>
+            <div class="mob-kv"><div class="mob-k">RB enriched</div><div class="mob-v sm">${p.rb_enriched ? 'Yes' : 'No'}</div></div>
+          </div>`;
+      }
+    }
+
+    // ── Cell Localization ──
+    _renderMobLocalization(scroll, gene, p);
+
+    // ── Orthologs ──
+    const orthoEl = scroll.querySelector('#mob-orthologs-inner');
+    if (orthoEl) {
+      if (!orthos.length) {
+        orthoEl.innerHTML = '<div style="font-style:italic;color:var(--mob-ink-3);font-size:14px;">No orthologs recorded</div>';
+      } else {
+        const rows = orthos.map(o => {
+          const g = o.peer;
+          if (!g) return '';
+          const col = g.strains?.color_hex ?? '#9ca3af';
+          const strainName = g.strains?.common_name ?? '?';
+          const label = g.gene_name ? `${esc(g.locus_tag)} <span style="color:var(--mob-ink-3);">${esc(g.gene_name)}</span>` : `<span style="color:var(--mob-ink-3);">${esc(g.locus_tag)}</span>`;
+          return `<div class="mob-tg-row" data-ortho-id="${g.id}" style="cursor:pointer;border-radius:10px;border:.5px solid var(--mob-line);margin-bottom:7px;">
+            <div style="width:4px;align-self:stretch;border-radius:3px;background:${col};flex-shrink:0;"></div>
+            <div style="flex:1;min-width:0;padding:2px 0;">
+              <div style="font-size:10.5px;font-weight:700;color:var(--mob-ink-3);letter-spacing:.04em;">${esc(strainName)}</div>
+              <div style="font-size:14px;font-weight:700;color:var(--mob-ink);margin-top:1px;">${label}</div>
+            </div>
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#c8cec9" stroke-width="2.2" stroke-linecap="round"><polyline points="9 18 15 12 9 6"/></svg>
+          </div>`;
+        }).join('');
+        orthoEl.innerHTML = rows;
+        orthoEl.querySelectorAll('[data-ortho-id]').forEach(row => {
+          row.addEventListener('click', () => {
+            const id = row.dataset.orthoId;
+            if (!id) return;
+            sb.from('genes')
+              .select('id,strain_id,locus_tag,gene_name,gene_symbol,product,sort_index,start_bp,end_bp,strand,functional_category,is_characterized,is_membrane_protein,is_hypothetical,is_dna_binding,is_t3_secreted,expression_pattern,strains!inner(common_name,color_hex),proteins(alphafold_results(thumbnail_path))')
+              .eq('id', id).single()
+              .then(({ data }) => { if (data) showGeneDetailMobile(data, _container); });
+          });
+        });
+      }
+    }
+
+    // ── Mutants ──
+    const mutEl = scroll.querySelector('#mob-mutants-inner');
+    if (mutEl) {
+      if (!mutants.length) {
+        mutEl.innerHTML = '<div style="font-style:italic;color:var(--mob-ink-3);font-size:14px;">No mutants target this gene</div>';
+      } else {
+        const TYPE_ACCENT = { transposon:'#059669', deletion:'#dc2626', chimera:'#7c3aed', chemical:'#2563eb', intron:'#ca8a04', recombination:'#db2777' };
+        const rows = mutants.map(m => {
+          const col = TYPE_ACCENT[m.mutation_type] ?? '#8b958f';
+          const pubDot = m.is_published
+            ? `<span style="font-size:10px;font-weight:700;padding:2px 7px;border-radius:4px;background:rgba(5,150,105,.09);color:#059669;border:1px solid rgba(5,150,105,.2);">Published</span>`
+            : `<span style="font-size:10px;font-weight:700;padding:2px 7px;border-radius:4px;background:rgba(180,83,9,.08);color:#b45309;border:1px solid rgba(180,83,9,.2);">Lab</span>`;
+          return `<div class="mob-tg-row" data-mut-id="${m.id}" style="cursor:pointer;border-radius:10px;border:.5px solid var(--mob-line);margin-bottom:7px;">
+            <div style="width:4px;align-self:stretch;border-radius:3px;background:${col};flex-shrink:0;"></div>
+            <div style="flex:1;min-width:0;padding:2px 0;">
+              <div style="font-family:var(--mob-mono);font-size:14px;font-weight:700;color:var(--mob-ink);">${esc(m.name || m.mutant_id)}</div>
+              <div style="font-size:12px;color:var(--mob-ink-3);margin-top:2px;">${esc(m.collection ?? '')} · ${esc(m.mutation_type ?? '')}</div>
+            </div>
+            ${pubDot}
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#c8cec9" stroke-width="2.2" stroke-linecap="round"><polyline points="9 18 15 12 9 6"/></svg>
+          </div>`;
+        }).join('');
+        mutEl.innerHTML = rows + `<div style="font-size:11px;color:var(--mob-ink-3);margin-top:4px;">${mutants.length} mutant${mutants.length > 1 ? 's' : ''} targeting this gene</div>`;
+        mutEl.querySelectorAll('[data-mut-id]').forEach(row => {
+          row.addEventListener('click', () => {
+            import('./mutants.js?v=96').then(({ _mobLoadMutantDetail }) => {
+              _mobLoadMutantDetail(row.dataset.mutId);
+            });
+          });
+        });
+      }
+    }
+  }).catch(err => console.warn('[ChlamAtlas] gene detail fetch:', err));
+}
+
+function _renderMobTranscriptomics(el, gene, exprs) {
+  if (!el) return;
+  const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+
+  const microarrayRows = exprs.filter(r => r.method === 'microarray');
+  if (!microarrayRows.length) {
+    el.innerHTML = gene.expression_pattern
+      ? `<div style="display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:999px;background:#eef2ef;font-weight:800;font-size:13px;color:var(--mob-ink);">
+           <span style="width:8px;height:8px;border-radius:50%;background:var(--mob-green);"></span>
+           ${esc(gene.expression_pattern)}
+         </div>`
+      : '<div style="font-style:italic;color:var(--mob-ink-3);font-size:14px;">No expression data</div>';
+    return;
   }
 
-  _buildMobGenomicContext(gene, scroll.querySelector('#mob-ctx-inner'));
+  const TP_ORDER = { T0:0, T1:1, T2:2, T3:3, T4:4, T5:5 };
+  const TP_LABEL = { T0:'1h', T1:'3h', T2:'8h', T3:'16h', T4:'24h', T5:'40h' };
+  const sorted = [...microarrayRows].sort((a, b) => (TP_ORDER[a.timepoint] ?? 99) - (TP_ORDER[b.timepoint] ?? 99));
+  const values = sorted.map(r => r.value ?? 0);
+  const maxVal = Math.max(...values, 1);
+
+  // CT-L2 qualitative (pattern label, no quantitative values)
+  if (values.every(v => v === 0) && sorted[0]?.pattern_label) {
+    const display = String(sorted[0].pattern_label).toUpperCase().replace(/_/g,' ');
+    el.innerHTML = `<div style="display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:999px;background:#eef2ef;font-weight:800;font-size:13px;color:var(--mob-ink);">
+        <span style="width:8px;height:8px;border-radius:50%;background:var(--mob-green);"></span>
+        ${esc(display)}
+      </div>
+      <div style="font-size:11px;color:var(--mob-ink-3);margin-top:6px;font-style:italic;">Qualitative · Nicholson et al. 2003</div>`;
+    return;
+  }
+
+  // CT-D quantitative bar chart
+  const bars = sorted.map(r => {
+    const h   = Math.round(((r.value ?? 0) / maxVal) * 44);
+    const pct = Math.max(h, 2);
+    const lbl = TP_LABEL[r.timepoint] ?? r.timepoint;
+    return `<div style="display:flex;flex-direction:column;align-items:center;flex:1;">
+      <div style="height:44px;display:flex;align-items:flex-end;width:100%;">
+        <div title="${lbl}: ${r.value ?? 0}" style="background:var(--mob-green);border-radius:3px 3px 0 0;width:100%;height:${pct}px;opacity:.85;"></div>
+      </div>
+      <div style="font-size:10px;color:var(--mob-ink-3);font-family:var(--mob-mono);margin-top:3px;">${lbl}</div>
+    </div>`;
+  }).join('');
+
+  el.innerHTML = `<div style="display:flex;align-items:flex-end;gap:3px;height:62px;padding-bottom:18px;position:relative;">
+      <div style="position:absolute;bottom:18px;left:0;right:0;height:1px;background:#e5e7eb;"></div>
+      ${bars}
+    </div>
+    <div style="font-size:11px;color:var(--mob-ink-3);margin-top:4px;font-style:italic;">CT-D microarray · Belland et al. 2003 · PMID 12815105</div>`;
+}
+
+function _renderMobLocalization(scroll, gene, protein) {
+  const el     = scroll.querySelector('#mob-loc-inner');
+  const headEl = scroll.querySelector('#mob-loc-head');
+  if (!el) return;
+  const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+
+  const source   = protein?.localization_source ?? null;
+  const slTerms  = protein?.subcellular_location_sl ?? [];
+  const goTerms  = protein?.subcellular_location_go ?? [];
+
+  let activeTerms = [];
+  let sourceBadge = '';
+  const badgeHtml = (label, col, bg) =>
+    `<span style="font-size:10px;font-weight:700;padding:2px 8px;border-radius:6px;background:${bg};color:${col};letter-spacing:.04em;margin-left:auto;">${label}</span>`;
+
+  if (source === 'user') {
+    activeTerms = slTerms.map(id => ({ id, label: locTermLabel(id) }));
+    sourceBadge = badgeHtml('Curated', '#065f46', '#d1fae5');
+  } else if (source === 'lab_flag') {
+    activeTerms = [{ id: 'SL-0204', label: 'Secreted' }];
+    sourceBadge = badgeHtml('ChlamAtlas', '#92400e', '#fef3c7');
+  } else if (source === 'uniprot_sl') {
+    activeTerms = slTerms.map(id => ({ id, label: locTermLabel(id) }));
+    sourceBadge = badgeHtml('UniProt', '#6b7280', '#f3f4f6');
+  } else if (source === 'uniprot_go') {
+    activeTerms = goTerms.map(id => ({ id, label: locTermLabel(id) }));
+    sourceBadge = badgeHtml('GO', '#6b7280', '#f3f4f6');
+  }
+
+  if (headEl && sourceBadge) headEl.innerHTML = `Cell Localization ${sourceBadge}`;
+
+  if (!activeTerms.length && !protein?.localization) {
+    el.innerHTML = '<div style="font-style:italic;color:var(--mob-ink-3);font-size:14px;">Location unknown</div>';
+    return;
+  }
+
+  const pills = activeTerms.length
+    ? activeTerms.map(t => `<span style="font-size:12px;font-weight:700;padding:5px 12px;border-radius:999px;background:#f3f4f6;color:#374151;border:1px solid #e5e7eb;">${esc(t.label)}</span>`).join('')
+    : protein?.localization?.split(';').filter(Boolean).map(s => `<span style="font-size:12px;font-weight:700;padding:5px 12px;border-radius:999px;background:#f3f4f6;color:#374151;border:1px solid #e5e7eb;">${esc(s.trim())}</span>`).join('') ?? '';
+
+  el.innerHTML = pills
+    ? `<div style="display:flex;flex-wrap:wrap;gap:7px;">${pills}</div>`
+    : '<div style="font-style:italic;color:var(--mob-ink-3);font-size:14px;">Location unknown</div>';
 }
 
 async function _buildMobGenomicContext(gene, inner) {
@@ -2923,8 +3194,8 @@ async function _buildMobGenomicContext(gene, inner) {
     .from('genes')
     .select('id,locus_tag,gene_name,gene_symbol,functional_category,strand,start_bp,end_bp,sort_index')
     .eq('strain_id', gene.strain_id)
-    .gte('sort_index', gene.sort_index - 5)
-    .lte('sort_index', gene.sort_index + 5)
+    .gte('sort_index', gene.sort_index - 2)
+    .lte('sort_index', gene.sort_index + 2)
     .order('sort_index');
 
   if (!neighbors || neighbors.length === 0) {
@@ -2936,7 +3207,7 @@ async function _buildMobGenomicContext(gene, inner) {
     const isFocal = String(g.id) === String(gene.id);
     const col     = CATEGORY_COLORS[g.functional_category] ?? CATEGORY_COLOR_DEFAULT;
     const bp      = (g.end_bp ?? 0) - (g.start_bp ?? 0);
-    const width   = Math.max(72, Math.min(150, bp * 0.05)) + 'px';
+    const width   = Math.max(52, Math.min(110, bp * 0.04)) + 'px';
     const isPlus  = g.strand === '+' || g.strand === '1' || g.strand === 1;
     const sym     = g.gene_symbol || g.gene_name || g.locus_tag.slice(-6);
     const opacity = isFocal ? '1' : '0.82';

--- a/web/js/views/genomes.js
+++ b/web/js/views/genomes.js
@@ -306,7 +306,7 @@ async function _mobFetchGenes(container) {
     .select(
       'id,locus_tag,gene_name,gene_symbol,product,functional_category,' +
       'is_characterized,is_hypothetical,is_t3_secreted,is_membrane_protein,' +
-      'sort_index,strand,start_bp,end_bp,strain_id,' +
+      'sort_index,strand,start_bp,end_bp,strain_id,updated_at,updated_by,' +
       'strains!inner(common_name),' +
       'proteins(alphafold_results(thumbnail_path))',
       { count: 'exact' }
@@ -2809,11 +2809,13 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
     return `rgba(${r},${g},${b},${a})`;
   };
 
+  const canEdit = state.userRole === 'lab_member' || state.userRole === 'admin';
+
   scroll.innerHTML = `
-    <!-- ── Header: gradient bleed ── -->
+    <!-- ── Header ── -->
     <div style="margin-top:calc(-1 * var(--mob-nav-h));padding-top:calc(var(--mob-nav-h) + 10px);
                 background:linear-gradient(180deg,${hexToRgba(color,.20)} 0%,${hexToRgba(color,.04)} 100%);
-                border-bottom:2px solid ${hexToRgba(color,.35)};padding-bottom:14px;">
+                border-bottom:1px solid ${hexToRgba(color,.25)};padding-bottom:14px;">
       <div class="mob-d-head" style="padding:0 12px 0 16px;">
         <div class="mob-d-thumb" style="background:${hexToRgba(color,.15)};">
           ${thumb
@@ -2824,7 +2826,11 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
           <div class="mob-d-title">${esc(displayName)}</div>
           ${locusShow ? `<span class="mob-d-loc">${esc(locusShow)}</span>` : ''}
         </div>
-        <div class="mob-d-actions" style="flex-shrink:0;">
+        <div class="mob-d-actions" style="flex-shrink:0;display:flex;align-items:center;gap:2px;">
+          ${canEdit ? `<button class="mob-edit-btn" aria-label="Edit gene"
+              style="background:none;border:none;padding:8px 4px;cursor:pointer;color:var(--mob-ink-3);">
+              <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/><path d="m15 5 4 4"/></svg>
+            </button>` : ''}
           <button class="mob-fav-btn${isFav ? ' saved-on' : ''}" data-id="${gene.id}" aria-label="Save gene"
             style="background:none;border:none;padding:8px 4px;cursor:pointer;color:${isFav ? '#e8b400' : 'var(--mob-ink-3)'};">
             <svg width="21" height="21" viewBox="0 0 24 24" fill="${isFav ? '#e8b400' : 'none'}" stroke="${isFav ? '#e8b400' : 'currentColor'}" stroke-width="2"><path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"/></svg>
@@ -2844,11 +2850,9 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
       </div>
     </div>
 
-    <!-- Desktop L→R top→bottom: Gene Info | Orthologs → Gene Map → Protein | Localization → Transcriptomics → Proteomics → Structure → Mutants -->
-
     <!-- ── Gene Info ── -->
-    <div class="mob-card">
-      <div class="mob-card-h">Gene Info</div>
+    <div class="mob-det-sec">
+      <div class="mob-det-h">Gene Info</div>
       <div class="mob-kv-grid">
         <div class="mob-kv"><div class="mob-k">Length</div><div class="mob-v sm">${gene.end_bp && gene.start_bp ? (gene.end_bp - gene.start_bp).toLocaleString() + ' bp' : '—'}</div></div>
         <div class="mob-kv"><div class="mob-k">Strand</div><div class="mob-v sm">${gene.strand === '+' || gene.strand === '1' ? '+ (sense)' : gene.strand ? '− (antisense)' : '—'}</div></div>
@@ -2858,73 +2862,75 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
     </div>
 
     <!-- ── Orthologs ── -->
-    <div class="mob-card">
-      <div class="mob-card-h">Orthologs</div>
-      <div id="mob-orthologs-inner" style="margin-top:10px;color:var(--mob-ink-3);font-size:13px;">Loading…</div>
+    <div class="mob-det-sec">
+      <div class="mob-det-h">Orthologs</div>
+      <div id="mob-orthologs-inner" style="color:var(--mob-ink-3);font-size:13px;">Loading…</div>
     </div>
 
-    <!-- ── Genomic Context ── -->
-    <div class="mob-card" id="mob-ctx-card">
-      <div class="mob-card-h">Genomic Context <span style="color:var(--mob-ink-3);font-weight:400;">${esc(strain)}</span></div>
-      <div id="mob-ctx-inner" style="margin-top:8px;min-height:80px;display:flex;align-items:center;justify-content:center;">
+    <!-- ── Genomic Context — flush full-width ── -->
+    <div class="mob-det-sec mob-det-sec--map">
+      <div class="mob-det-h">Genomic Context <span style="color:var(--mob-ink-3);font-weight:400;font-size:13px;">${esc(strain)}</span></div>
+      <div id="mob-ctx-inner" style="min-height:80px;display:flex;align-items:center;justify-content:center;overflow-x:auto;">
         <span style="color:var(--mob-ink-3);font-size:13px;">Loading…</span>
       </div>
     </div>
 
     <!-- ── Protein ── -->
-    <div class="mob-card">
-      <div class="mob-card-h">Protein</div>
+    <div class="mob-det-sec">
+      <div class="mob-det-h">Protein</div>
       <div class="mob-kv-grid" id="mob-protein-kv">
         <div class="mob-kv"><div class="mob-k">Mass</div><div class="mob-v sm">—</div></div>
         <div class="mob-kv"><div class="mob-k">Length</div><div class="mob-v sm">—</div></div>
         <div class="mob-kv"><div class="mob-k">TM domains</div><div class="mob-v sm">—</div></div>
         <div class="mob-kv"><div class="mob-k">Signal peptide</div><div class="mob-v sm">—</div></div>
       </div>
-      <div id="mob-protein-product" style="display:none;margin-top:12px;">
-        <div class="mob-k" style="font-family:var(--mob-mono);font-size:10.5px;letter-spacing:.08em;text-transform:uppercase;color:var(--mob-ink-3);margin-bottom:5px;">Product</div>
+      <div id="mob-protein-product" style="display:none;margin-top:14px;">
+        <div class="mob-k" style="font-size:10.5px;letter-spacing:.06em;text-transform:uppercase;color:var(--mob-ink-3);margin-bottom:4px;">Product</div>
         <div id="mob-protein-product-text" style="font-size:14px;color:var(--mob-ink);line-height:1.5;"></div>
       </div>
     </div>
 
     <!-- ── Cell Localization ── -->
-    <div class="mob-card">
-      <div class="mob-card-h" id="mob-loc-head">Cell Localization</div>
-      <div id="mob-loc-inner" style="margin-top:10px;color:var(--mob-ink-3);font-size:13px;">Loading…</div>
+    <div class="mob-det-sec">
+      <div class="mob-det-h" id="mob-loc-head">Cell Localization</div>
+      <div id="mob-loc-inner" style="color:var(--mob-ink-3);font-size:13px;">Loading…</div>
     </div>
 
     <!-- ── Transcriptomics ── -->
-    <div class="mob-card">
-      <div class="mob-card-h">Transcriptomics</div>
-      <div id="mob-transcriptomics-inner" style="margin-top:10px;color:var(--mob-ink-3);font-size:13px;">Loading…</div>
+    <div class="mob-det-sec">
+      <div class="mob-det-h">Transcriptomics</div>
+      <div id="mob-transcriptomics-inner" style="color:var(--mob-ink-3);font-size:13px;">Loading…</div>
     </div>
 
     <!-- ── EB / RB Proteomics ── -->
-    <div class="mob-card">
-      <div class="mob-card-h">EB / RB Proteomics</div>
-      <div id="mob-proteomics-inner" style="margin-top:12px;color:var(--mob-ink-3);font-size:14px;">Loading…</div>
+    <div class="mob-det-sec">
+      <div class="mob-det-h">EB / RB Proteomics</div>
+      <div id="mob-proteomics-inner" style="color:var(--mob-ink-3);font-size:14px;">Loading…</div>
     </div>
 
     <!-- ── Structure ── -->
-    <div class="mob-card">
-      <div class="mob-card-h">Structure</div>
-      <div id="mob-structure-inner" style="margin-top:12px;">
-        ${thumb
-          ? `<div id="mob-struct-thumb-wrap" style="position:relative;border-radius:12px;overflow:hidden;border:.5px solid var(--mob-line);">
-               <img id="mob-struct-thumb" src="${esc(thumb)}" alt="AlphaFold structure" style="width:100%;max-height:200px;object-fit:contain;display:block;">
-             </div>`
-          : '<div style="color:var(--mob-ink-3);font-size:13px;">No structure available</div>'}
-      </div>
-      <div id="mob-structure-meta" style="margin-top:10px;"></div>
-      <div id="mob-struct-load-wrap"></div>
+    <div class="mob-det-sec">
+      <div class="mob-det-h">Structure</div>
+      <div id="mob-structure-inner"></div>
     </div>
 
     <!-- ── Mutants ── -->
-    <div class="mob-card">
-      <div class="mob-card-h">Mutants</div>
-      <div id="mob-mutants-inner" style="margin-top:10px;color:var(--mob-ink-3);font-size:13px;">Loading…</div>
+    <div class="mob-det-sec">
+      <div class="mob-det-h" id="mob-mutants-head">Mutants</div>
+      <div id="mob-mutants-inner" style="color:var(--mob-ink-3);font-size:13px;">Loading…</div>
+    </div>
+
+    <!-- ── Footer ── -->
+    <div id="mob-detail-footer" style="padding:16px 16px 8px;border-top:1px solid var(--mob-line);">
+      <div style="font-size:11px;color:var(--mob-ink-3);" id="mob-updated-stamp"></div>
     </div>
 
     <div class="mob-pad-bottom"></div>`;
+
+  // ── Edit button ──
+  scroll.querySelector('.mob-edit-btn')?.addEventListener('click', () => {
+    openGeneEditModal(gene, null, scroll, _container);
+  });
 
   // ── Favorite toggle ──
   scroll.querySelector('.mob-fav-btn')?.addEventListener('click', async (e) => {
@@ -2939,6 +2945,15 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
     if (nowFav) btn.classList.add('mob-star-pop');
     btn.addEventListener('animationend', () => btn.classList.remove('mob-star-pop'), { once: true });
   });
+
+  // ── Last updated footer ──
+  if (gene.updated_at) {
+    const stamp = scroll.querySelector('#mob-updated-stamp');
+    if (stamp) {
+      const d = new Date(gene.updated_at).toLocaleDateString('en-US', { year:'numeric', month:'short', day:'numeric' });
+      stamp.textContent = `Last updated ${d}${gene.updated_by ? ` · ${gene.updated_by}` : ''}`;
+    }
+  }
 
   // ── Genomic context (fast, separate) ──
   _buildMobGenomicContext(gene, scroll.querySelector('#mob-ctx-inner'));
@@ -3045,22 +3060,31 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
         mutEl.innerHTML = '<div style="font-style:italic;color:var(--mob-ink-3);font-size:14px;">No mutants target this gene</div>';
       } else {
         const TYPE_ACCENT = { transposon:'#059669', deletion:'#dc2626', chimera:'#7c3aed', chemical:'#2563eb', intron:'#ca8a04', recombination:'#db2777' };
-        const rows = mutants.map(m => {
+        // Update header to show count
+        const mutHead = scroll.querySelector('#mob-mutants-head');
+        if (mutHead) mutHead.textContent = `Mutants (${mutants.length})`;
+
+        const rows = mutants.map((m, i) => {
+          const isChimera = m.mutation_type === 'chimera';
+          // Chimeras and recombinants: use mutant_id (RC###) as primary
+          const primary   = isChimera ? m.mutant_id : (m.name || m.mutant_id);
+          const secondary = isChimera ? '' : (m.name ? m.mutant_id : '');
           const col = TYPE_ACCENT[m.mutation_type] ?? '#8b958f';
-          const pubDot = m.is_published
+          const pubBadge = m.is_published
             ? `<span style="font-size:10px;font-weight:700;padding:2px 7px;border-radius:4px;background:rgba(5,150,105,.09);color:#059669;border:1px solid rgba(5,150,105,.2);">Published</span>`
             : `<span style="font-size:10px;font-weight:700;padding:2px 7px;border-radius:4px;background:rgba(180,83,9,.08);color:#b45309;border:1px solid rgba(180,83,9,.2);">Lab</span>`;
-          return `<div class="mob-tg-row" data-mut-id="${m.id}" style="cursor:pointer;border-radius:10px;border:.5px solid var(--mob-line);margin-bottom:7px;">
-            <div style="width:4px;align-self:stretch;border-radius:3px;background:${col};flex-shrink:0;"></div>
-            <div style="flex:1;min-width:0;padding:2px 0;">
-              <div style="font-family:var(--mob-mono);font-size:14px;font-weight:700;color:var(--mob-ink);">${esc(m.name || m.mutant_id)}</div>
+          const divider = i < mutants.length - 1 ? `border-bottom:1px solid var(--mob-line);` : '';
+          return `<div data-mut-id="${m.id}" style="display:flex;align-items:center;gap:10px;padding:10px 0;cursor:pointer;${divider}">
+            <div style="width:4px;height:36px;border-radius:3px;background:${col};flex-shrink:0;"></div>
+            <div style="flex:1;min-width:0;">
+              <div style="font-family:var(--mob-mono);font-size:14px;font-weight:700;color:var(--mob-ink);">${esc(primary)}${secondary ? ` <span style="font-weight:400;color:var(--mob-ink-3);font-size:12px;">${esc(secondary)}</span>` : ''}</div>
               <div style="font-size:12px;color:var(--mob-ink-3);margin-top:2px;">${esc(m.collection ?? '')} · ${esc(m.mutation_type ?? '')}</div>
             </div>
-            ${pubDot}
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#c8cec9" stroke-width="2.2" stroke-linecap="round"><polyline points="9 18 15 12 9 6"/></svg>
+            ${pubBadge}
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#c8cec9" stroke-width="2.2" stroke-linecap="round"><polyline points="9 18 15 12 9 6"/></svg>
           </div>`;
         }).join('');
-        mutEl.innerHTML = rows + `<div style="font-size:11px;color:var(--mob-ink-3);margin-top:4px;">${mutants.length} mutant${mutants.length > 1 ? 's' : ''} targeting this gene</div>`;
+        mutEl.innerHTML = rows;
         mutEl.querySelectorAll('[data-mut-id]').forEach(row => {
           row.addEventListener('click', () => {
             import('./mutants.js?v=96').then(({ _mobLoadMutantDetail }) => {
@@ -3075,9 +3099,7 @@ function _renderGeneDetailMobileHTML(gene, scroll) {
 
 function _renderMobStructure(scroll, p) {
   const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
-  const structEl   = scroll.querySelector('#mob-structure-inner');
-  const metaEl     = scroll.querySelector('#mob-structure-meta');
-  const loadWrap   = scroll.querySelector('#mob-struct-load-wrap');
+  const structEl = scroll.querySelector('#mob-structure-inner');
   if (!structEl) return;
 
   const afRows    = p?.alphafold_results ?? [];
@@ -3158,9 +3180,11 @@ function _renderMobStructure(scroll, p) {
       : `data-url="${esc(mmcif ?? '')}"`;
 
     return `
-      <div id="mob-struct-viewer-wrap" ${viewerAttrs}
-        style="position:relative;border-radius:12px;overflow:hidden;border:.5px solid var(--mob-line);background:#0a1628;height:240px;margin-bottom:10px;">
-        ${thumb ? `<img id="mob-struct-thumb" src="${esc(thumb)}" style="width:100%;height:100%;object-fit:contain;display:block;">` : ''}
+      <div class="mob-det-card" style="margin-bottom:12px;">
+        <div id="mob-struct-viewer-wrap" ${viewerAttrs}
+          style="position:relative;overflow:hidden;background:#0a1628;height:240px;">
+          ${thumb ? `<img id="mob-struct-thumb" src="${esc(thumb)}" style="width:100%;height:100%;object-fit:contain;display:block;">` : ''}
+        </div>
       </div>
       <div style="font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--mob-ink-3);margin-bottom:4px;">${srcLabel}</div>
       ${crystalId}
@@ -3170,11 +3194,9 @@ function _renderMobStructure(scroll, p) {
   }
 
   structEl.innerHTML = tabRow + `<div id="mob-struct-body">${bodyFor(activeRecord)}</div>`;
-  if (metaEl) metaEl.innerHTML = '';
-  if (loadWrap) loadWrap.innerHTML = '';
 
   // Wire tabs
-  const card = structEl.closest('.mob-card');
+  const card = structEl.closest('.mob-det-sec');
   card?.querySelectorAll('.mob-struct-tab').forEach(btn => {
     btn.addEventListener('click', () => {
       activeTabId = btn.dataset.tab;
@@ -3366,9 +3388,9 @@ function _renderMobLocalization(scroll, gene, protein) {
         `<span style="font-size:12.5px;font-weight:700;padding:5px 12px;border-radius:999px;background:#f3f4f6;color:#374151;border:1px solid #e5e7eb;">${esc(s.trim())}</span>`
       ).join('');
 
-  // Render diagram container + pills
+  // Render: diagram in a contained card, pills below
   el.innerHTML = `
-    ${diagramUrl ? `<div id="mob-sbp-svg" style="max-width:100%;overflow:hidden;margin-bottom:10px;display:flex;align-items:center;justify-content:center;min-height:60px;">
+    ${diagramUrl ? `<div class="mob-det-card" id="mob-sbp-svg" style="margin-bottom:12px;display:flex;align-items:center;justify-content:center;min-height:70px;padding:8px;">
       <div style="color:var(--mob-ink-3);font-size:12px;">Loading diagram…</div>
     </div>` : ''}
     ${pills ? `<div style="display:flex;flex-wrap:wrap;gap:7px;">${pills}</div>` : ''}`;

--- a/web/js/views/genomes.js
+++ b/web/js/views/genomes.js
@@ -1,5 +1,6 @@
 // ChlamAtlas — Genomes tab
 import { sb, state, toggleFavoriteDB } from '../client.js?v=82';
+import { isMobileViewport, onMobScroll, pushMobileDetail } from '../app.js?v=82';
 
 const STRAINS = [
   { id: 'CT-L2', label: 'CT L2/434', icon: '/design/icons_transparent/L2icon_transparent.png' },
@@ -177,6 +178,306 @@ async function openGeneById(geneId, container) {
   }
 }
 
+// ─── Mobile gene list ─────────────────────────────────────
+function _renderMobileGeneList(container) {
+  const currentStrain = STRAINS.find(s => s.id === _strain) ?? STRAINS[0];
+
+  container.style.padding = '0';
+  container.innerHTML = `
+    <div class="mob-lt-wrap" style="padding-top:8px;">
+      <div class="mob-lt-eyebrow">Genomes</div>
+      <h1 class="mob-lt-title">${_strain}</h1>
+    </div>
+
+    <div class="mob-strain-ctx">
+      <img src="${currentStrain.icon}" alt="${currentStrain.id}" onerror="this.style.display='none'">
+      <div style="flex:1;min-width:0;">
+        <div class="spc">${currentStrain.label}</div>
+        <div class="cnt" id="mob-gene-count">Loading…</div>
+      </div>
+      <button class="mob-switch-btn" id="mob-strain-switch-btn">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M7 16V4m0 0L3 8m4-4l4 4"/><path d="M17 8v12m0 0l4-4m-4 4l-4-4"/></svg>
+        Switch
+      </button>
+    </div>
+
+    <div class="mob-sticky-bar" id="mob-gene-toolbar">
+      <div class="mob-search-field">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#9aa39c" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <input id="mob-gene-search" type="search" autocomplete="off"
+          placeholder="Search genes, locus, products…" />
+        <button id="mob-gene-search-clear" style="display:none;background:none;border:none;color:var(--mob-ink-3);cursor:pointer;padding:0;font-size:14px;">✕</button>
+      </div>
+      <div class="mob-chip-row" style="padding:0;">
+        <div class="mob-seg" id="mob-gene-sort">
+          <button class="mob-seg-btn active" data-sort="locus_tag">Locus</button>
+          <button class="mob-seg-btn" data-sort="gene_name">A–Z</button>
+          <button class="mob-seg-btn" data-sort="functional_category">Function</button>
+        </div>
+        <div style="width:.5px;background:var(--mob-line);margin:6px 0;flex-shrink:0;"></div>
+        <button class="mob-chip active" data-filter="all">All</button>
+        <button class="mob-chip" data-filter="characterized">Characterized</button>
+        <button class="mob-chip" data-filter="inc">
+          <span class="mob-dot" style="background:#E4B47E;"></span>Inc
+        </button>
+        <button class="mob-chip" data-filter="secreted">
+          <span class="mob-dot" style="background:#00A551;"></span>Secreted
+        </button>
+        <button class="mob-chip" data-filter="hypothetical">Hypothetical</button>
+      </div>
+    </div>
+
+    <div id="mob-gene-list" style="background:var(--mob-bg);"></div>
+    <div id="mob-gene-sentinel" style="height:1px;"></div>
+    <div class="mob-pad-bottom"></div>`;
+
+  onMobScroll(container, 60, _strain);
+
+  const searchInput = container.querySelector('#mob-gene-search');
+  const searchClear = container.querySelector('#mob-gene-search-clear');
+  let searchTimer;
+  searchInput.addEventListener('input', () => {
+    _search = searchInput.value;
+    searchClear.style.display = _search ? '' : 'none';
+    clearTimeout(searchTimer);
+    searchTimer = setTimeout(() => { _offset = 0; _mobFetchGenes(container); }, 250);
+  });
+  searchClear.addEventListener('click', () => {
+    searchInput.value = ''; _search = '';
+    searchClear.style.display = 'none';
+    _offset = 0; _mobFetchGenes(container);
+  });
+
+  container.querySelectorAll('#mob-gene-sort .mob-seg-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      container.querySelectorAll('#mob-gene-sort .mob-seg-btn').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      _sortField = btn.dataset.sort;
+      _sortAsc   = true;
+      _offset    = 0;
+      _mobFetchGenes(container);
+    });
+  });
+
+  container.querySelectorAll('.mob-chip[data-filter]').forEach(chip => {
+    chip.addEventListener('click', () => {
+      container.querySelectorAll('.mob-chip[data-filter]').forEach(c => c.classList.remove('active'));
+      chip.classList.add('active');
+      const f = chip.dataset.filter;
+      _filters = { favorites: false, characterized: false, hypothetical: false,
+                   inc: false, membrane: false, secreted: false, dnaBinding: false,
+                   hasAf3: false, hasCrystal: false };
+      if (f === 'characterized') _filters.characterized = true;
+      if (f === 'inc')           _filters.inc           = true;
+      if (f === 'secreted')      _filters.secreted      = true;
+      if (f === 'hypothetical')  _filters.hypothetical  = true;
+      _categoryFilter = null;
+      _offset = 0;
+      _mobFetchGenes(container);
+    });
+  });
+
+  container.querySelector('#mob-strain-switch-btn').addEventListener('click', () => {
+    _showMobStrainSheet(container);
+  });
+
+  _mobFetchGenes(container);
+}
+
+async function _mobFetchGenes(container) {
+  if (_loading) return;
+  _loading = true;
+
+  const list = container.querySelector('#mob-gene-list');
+  if (!list) { _loading = false; return; }
+
+  if (_offset === 0) {
+    list.innerHTML = '<div style="padding:24px 20px;color:var(--mob-ink-3);font-size:14px;">Loading…</div>';
+  }
+
+  let query = sb
+    .from('genes')
+    .select(
+      'id,locus_tag,gene_name,gene_symbol,product,functional_category,' +
+      'is_characterized,is_hypothetical,is_t3_secreted,is_membrane_protein,' +
+      'sort_index,strand,start_bp,end_bp,strain_id,' +
+      'strains!inner(common_name),' +
+      'proteins(alphafold_results(thumbnail_path))',
+      { count: 'exact' }
+    )
+    .eq('strains.common_name', _strain)
+    .order(_sortField, { ascending: _sortAsc })
+    .range(_offset, _offset + PAGE_SIZE - 1);
+
+  if (_search) {
+    query = query.or(
+      `locus_tag.ilike.%${_search}%,gene_name.ilike.%${_search}%,` +
+      `gene_symbol.ilike.%${_search}%,product.ilike.%${_search}%`
+    );
+  }
+  if (_filters.characterized) query = query.eq('is_characterized', true);
+  if (_filters.hypothetical)  query = query.eq('is_hypothetical',  true);
+  if (_filters.inc)           query = query.eq('functional_category', 'Inclusion membrane protein');
+  if (_filters.secreted)      query = query.eq('is_t3_secreted', true);
+  if (_categoryFilter)        query = query.eq('functional_category', _categoryFilter);
+
+  let data, count;
+  try {
+    ({ data, count } = await query);
+  } catch (err) {
+    _loading = false;
+    console.error('[ChlamAtlas] _mobFetchGenes error:', err);
+    const errList = container.querySelector('#mob-gene-list');
+    if (errList && _offset === 0) errList.innerHTML = '<div style="padding:24px 20px;color:#ef4444;font-size:14px;">Error loading genes. Please try again.</div>';
+    return;
+  }
+  _loading = false;
+
+  if (!data) return;
+
+  data.forEach(g => _geneCache.set(String(g.id), g));
+
+  _total   = count ?? 0;
+  _hasMore = _offset + data.length < _total;
+  _offset += data.length;
+
+  const countEl = container.querySelector('#mob-gene-count');
+  if (countEl) countEl.textContent = `${_total.toLocaleString()} genes`;
+
+  const html = _mobGroupAndRenderGenes(data);
+  if (_offset <= data.length) {
+    list.innerHTML = html || '<div style="padding:24px 20px;color:var(--mob-ink-3);font-size:14px;text-align:center;">No genes found.</div>';
+  } else {
+    list.insertAdjacentHTML('beforeend', html);
+  }
+
+  list.querySelectorAll('.mob-grow:not([data-wired])').forEach(row => {
+    row.dataset.wired = '1';
+    row.addEventListener('click', () => {
+      const gene = _geneCache.get(row.dataset.id);
+      if (gene) showGeneDetailMobile(gene, container);
+    });
+  });
+
+  _mobSetupInfiniteScroll(container);
+}
+
+function _mobGroupAndRenderGenes(genes) {
+  if (!genes.length) return '';
+
+  const groups = new Map();
+  genes.forEach(g => {
+    let key;
+    if (_sortField === 'functional_category') key = g.functional_category ?? 'Unknown';
+    else if (_sortField === 'gene_name') key = g.gene_name ? g.gene_name[0].toUpperCase() : '#';
+    else key = g.locus_tag.slice(0, -3) + '___';
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(g);
+  });
+
+  const stickyTop = _mobToolbarHeight();
+  let html = '';
+  groups.forEach((rows, key) => {
+    const catColor = _sortField === 'functional_category'
+      ? (CATEGORY_COLORS[key] ?? CATEGORY_COLOR_DEFAULT) : null;
+    const dot = catColor ? `<span style="width:10px;height:10px;border-radius:3px;background:${catColor};flex-shrink:0;display:inline-block;"></span>` : '';
+    html += `
+      <div class="mob-section-h" style="top:${stickyTop}px;">
+        ${dot}<span>${key}</span>
+        <span class="mob-sh-count">· ${rows.length}</span>
+      </div>
+      <div style="background:var(--mob-paper);">
+        ${rows.map((g, i) => _mobGeneRow(g, i < rows.length - 1)).join('')}
+      </div>`;
+  });
+  return html;
+}
+
+function _mobToolbarHeight() {
+  const bar = document.querySelector('#mob-gene-toolbar');
+  const navH = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--mob-nav-h')) || 52;
+  return bar ? bar.getBoundingClientRect().height + navH : navH + 116;
+}
+
+function _mobGeneRow(g, hasSep) {
+  const color   = CATEGORY_COLORS[g.functional_category] ?? CATEGORY_COLOR_DEFAULT;
+  const isFav   = state.favorites.genes.has(String(g.id));
+  const thumb   = g.proteins?.alphafold_results?.find(r => r.thumbnail_path)?.thumbnail_path;
+  const display = g.gene_name || g.gene_symbol || g.locus_tag;
+  const chevron = `<svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><polyline points="9 18 15 12 9 6"/></svg>`;
+  const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+
+  return `
+    <div class="mob-grow" data-id="${g.id}">
+      <div class="mob-bar" style="background:${color};"></div>
+      <div class="mob-thumb mob-stile">
+        ${thumb
+          ? `<img src="${esc(thumb)}" alt="structure" loading="lazy">`
+          : `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="${color}" stroke-width="1.5" opacity="0.5"><circle cx="12" cy="12" r="8"/><circle cx="12" cy="12" r="4"/></svg>`}
+      </div>
+      <div class="mob-meta">
+        <div class="mob-gname">${esc(display)}${g.gene_name ? `<span class="mob-loc">${esc(g.locus_tag)}</span>` : ''}</div>
+        <div class="mob-gfunc">${esc(g.functional_category ?? '')}</div>
+      </div>
+      ${state.user ? `<button class="mob-star${isFav ? ' on' : ''}" data-fav-id="${g.id}" aria-label="Save">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="${isFav ? '#e8b400' : 'none'}" stroke="${isFav ? '#e8b400' : 'currentColor'}" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+      </button>` : ''}
+      <span class="mob-chev">${chevron}</span>
+      ${hasSep ? '<div class="mob-sep"></div>' : ''}
+    </div>`;
+}
+
+function _mobSetupInfiniteScroll(container) {
+  if (!_hasMore) return;
+  const sentinel = container.querySelector('#mob-gene-sentinel');
+  if (!sentinel) return;
+  if (sentinel._obs) {
+    sentinel._obs.disconnect();
+    sentinel._obs = null;
+  }
+  const obs = new IntersectionObserver(entries => {
+    if (entries[0].isIntersecting && !_loading && _hasMore) _mobFetchGenes(container);
+  }, { root: container, threshold: 0 });
+  obs.observe(sentinel);
+  sentinel._obs = obs;
+}
+
+function _showMobStrainSheet(container) {
+  document.getElementById('mob-strain-sheet')?.remove();
+
+  const backdrop = document.createElement('div');
+  backdrop.id = 'mob-strain-sheet';
+  backdrop.className = 'mob-sheet-backdrop';
+  backdrop.innerHTML = `
+    <div class="mob-sheet" onclick="event.stopPropagation()">
+      <div class="mob-sheet-handle"></div>
+      <div class="mob-sheet-caption">Switch strain</div>
+      ${STRAINS.map(s => `
+        <div class="mob-strain-sheet-row" data-id="${s.id}"
+          style="display:flex;align-items:center;gap:13px;padding:12px 8px;border-radius:14px;cursor:pointer;
+                 background:${s.id === _strain ? '#f1f6f3' : 'transparent'};">
+          <img src="${s.icon}" alt="${s.id}" style="width:38px;height:38px;object-fit:contain;">
+          <div style="flex:1;">
+            <div style="font-weight:800;font-size:16px;color:${s.id === 'CT-L2' ? '#2f9e6e' : s.id === 'CT-D' ? '#b14a93' : '#3f7fc4'};">${s.id}</div>
+            <div style="font-size:13px;font-style:italic;color:var(--mob-ink-2);">${s.label}</div>
+          </div>
+          ${s.id === _strain ? '<span style="color:var(--mob-green);font-weight:800;">✓</span>' : ''}
+        </div>`).join('')}
+    </div>`;
+
+  backdrop.addEventListener('click', () => backdrop.remove());
+  backdrop.querySelectorAll('.mob-strain-sheet-row').forEach(row => {
+    row.addEventListener('click', () => {
+      _strain = row.dataset.id;
+      backdrop.remove();
+      _offset = 0; _search = '';
+      _renderMobileGeneList(container);
+    });
+  });
+
+  document.body.appendChild(backdrop);
+}
+
 // ─── Gene list ────────────────────────────────────────────
 
 function showGeneList(container) {
@@ -187,8 +488,12 @@ function showGeneList(container) {
   if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
 
   container.style.padding = '0';
+  if (isMobile) {
+    _renderMobileGeneList(container);
+    return;
+  }
   container.innerHTML = `
-    <div style="display:${isMobile ? 'block' : 'grid'};grid-template-columns:260px 1fr;height:calc(100vh - 56px${isMobile ? ' - 52px' : ''});width:100%;overflow:hidden;padding:0 12px;box-sizing:border-box;">
+    <div style="display:grid;grid-template-columns:260px 1fr;height:calc(100vh - 56px);width:100%;overflow:hidden;padding:0 12px;box-sizing:border-box;">
 
       <!-- ── List panel ── -->
       <div id="list-panel" style="border-right:1px solid #ececec;display:flex;flex-direction:column;overflow:hidden;">
@@ -2446,13 +2751,235 @@ function showGeneDetailDesktop(gene, container) {
   // Fire async queries in parallel
   loadDetailAsync(detail, gene);
 }
-function showGeneDetailMobile(gene, container) {
-  // Full-screen mobile detail — shares section renderers with desktop.
-  // TODO: implement tab bar in a follow-up session.
-  // For now: fall back to desktop layout inside the full container.
-  container.querySelector('#detail-panel').style.display = 'block';
-  container.querySelector('#list-panel').style.display   = 'none';
-  showGeneDetailDesktop(gene, container);
+function showGeneDetailMobile(gene, _container) {
+  const title = gene.gene_name || gene.gene_symbol || gene.locus_tag;
+  pushMobileDetail({
+    title,
+    render: (scroll) => {
+      _renderGeneDetailMobileHTML(gene, scroll);
+    },
+  });
+}
+
+function _renderGeneDetailMobileHTML(gene, scroll) {
+  const color      = CATEGORY_COLORS[gene.functional_category] ?? CATEGORY_COLOR_DEFAULT;
+  const catBadge   = CATEGORY_BADGE[gene.functional_category] ?? { bg:'#f9fafb', text:'#6b7280', border:'#e5e7eb' };
+  const isFav      = state.favorites.genes.has(String(gene.id));
+  const thumb      = gene.proteins?.alphafold_results?.find(r => r.thumbnail_path)?.thumbnail_path;
+  const strain     = gene.strains?.common_name ?? _strain;
+  const displayName = gene.gene_name || gene.gene_symbol || gene.locus_tag;
+  const locusShow   = gene.gene_name ? gene.locus_tag : '';
+  const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+
+  const hexToRgba = (hex, a) => {
+    if (!hex || !/^#[0-9A-Fa-f]{6}$/.test(hex)) return `rgba(0,0,0,${a})`;
+    const r = parseInt(hex.slice(1,3),16), g = parseInt(hex.slice(3,5),16), b = parseInt(hex.slice(5,7),16);
+    return `rgba(${r},${g},${b},${a})`;
+  };
+
+  scroll.innerHTML = `
+    <div style="background:${hexToRgba(color,.08)};border-bottom:3px solid ${color};padding-bottom:12px;">
+      <div class="mob-d-head">
+        <div class="mob-d-thumb" style="background:${hexToRgba(color,.15)};">
+          ${thumb
+            ? `<img src="${esc(thumb)}" alt="structure" loading="lazy">`
+            : `<svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="${color}" stroke-width="1.5"><circle cx="12" cy="12" r="8"/><circle cx="12" cy="12" r="4"/></svg>`}
+        </div>
+        <div class="mob-d-title-block">
+          <div class="mob-d-title">${esc(displayName)}</div>
+          ${locusShow ? `<span class="mob-d-loc">${esc(locusShow)}</span>` : ''}
+        </div>
+        <div class="mob-d-actions">
+          <button class="mob-gbtn mob-fav-btn${isFav ? ' saved-on' : ''}" data-id="${gene.id}" aria-label="Save gene">
+            <svg width="19" height="19" viewBox="0 0 24 24" fill="${isFav ? '#e8b400' : 'none'}" stroke="${isFav ? '#e8b400' : 'currentColor'}" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+          </button>
+        </div>
+      </div>
+      <div class="mob-tags-row" style="padding:0 20px 0;">
+        <span class="mob-tag" style="color:${color};border-color:${color};background:${hexToRgba(color,.1)};">${esc(strain)}</span>
+        ${gene.functional_category ? `<span class="mob-tag" style="color:${catBadge.text};border-color:${catBadge.border};background:${catBadge.bg};">${esc(gene.functional_category)}</span>` : ''}
+        ${gene.is_characterized ? `<span class="mob-tag" style="color:#1c8c7e;border-color:#1c8c7e;background:rgba(28,140,126,.08);">Characterized</span>` : ''}
+        ${gene.is_t3_secreted   ? `<span class="mob-tag" style="color:#7c3aed;border-color:#7c3aed;background:rgba(124,58,237,.08);">T3 Secreted</span>` : ''}
+        ${gene.is_dna_binding   ? `<span class="mob-tag" style="color:#b45309;border-color:#b45309;background:rgba(180,83,9,.08);">DNA Binding</span>` : ''}
+      </div>
+      <div class="mob-meta-row" style="padding:8px 20px 0;">
+        <a class="mob-copybtn" href="https://www.uniprot.org/uniprot/?query=${esc(gene.locus_tag)}" target="_blank" rel="noopener">UniProt ↗</a>
+        <a class="mob-copybtn" href="https://www.ncbi.nlm.nih.gov/gene/?term=${esc(gene.locus_tag)}" target="_blank" rel="noopener">NCBI ↗</a>
+      </div>
+    </div>
+
+    <div class="mob-card">
+      <div class="mob-card-h">Gene Info</div>
+      <div class="mob-kv-grid">
+        <div class="mob-kv"><div class="mob-k">Length</div><div class="mob-v sm">${gene.end_bp && gene.start_bp ? (gene.end_bp - gene.start_bp).toLocaleString() + ' bp' : '—'}</div></div>
+        <div class="mob-kv"><div class="mob-k">Strand</div><div class="mob-v sm">${gene.strand === '+' || gene.strand === '1' ? '+ (sense)' : gene.strand ? '− (antisense)' : '—'}</div></div>
+        <div class="mob-kv"><div class="mob-k">Position</div><div class="mob-v sm">${gene.start_bp ? gene.start_bp.toLocaleString() + '–' + (gene.end_bp ?? '?').toLocaleString() : '—'}</div></div>
+        <div class="mob-kv"><div class="mob-k">Organism</div><div class="mob-v sm" style="font-style:italic;">${esc(gene.strains?.common_name ?? _strain)}</div></div>
+      </div>
+    </div>
+
+    <div class="mob-card" id="mob-ctx-card">
+      <div class="mob-card-h">Genomic Context <span style="color:var(--mob-ink-3);font-weight:400;">${esc(strain)} chromosome</span></div>
+      <div id="mob-ctx-inner" style="margin-top:8px;min-height:80px;display:flex;align-items:center;justify-content:center;">
+        <span style="color:var(--mob-ink-3);font-size:13px;">Loading…</span>
+      </div>
+    </div>
+
+    <div class="mob-card">
+      <div class="mob-card-h">Protein</div>
+      <div class="mob-kv-grid" id="mob-protein-kv">
+        <div class="mob-kv"><div class="mob-k">Mass</div><div class="mob-v sm">—</div></div>
+        <div class="mob-kv"><div class="mob-k">Length</div><div class="mob-v sm">—</div></div>
+        <div class="mob-kv"><div class="mob-k">TM domains</div><div class="mob-v sm">—</div></div>
+        <div class="mob-kv"><div class="mob-k">Signal peptide</div><div class="mob-v sm">—</div></div>
+      </div>
+    </div>
+
+    <div class="mob-card">
+      <div class="mob-card-h">Structure</div>
+      <div id="mob-structure-inner" style="margin-top:12px;text-align:center;color:var(--mob-ink-3);font-size:13px;">
+        ${thumb
+          ? `<img src="${esc(thumb)}" alt="AlphaFold structure" style="width:100%;max-height:180px;object-fit:contain;border-radius:12px;border:.5px solid var(--mob-line);">`
+          : 'No structure available'}
+      </div>
+    </div>
+
+    <div class="mob-card">
+      <div class="mob-card-h">Transcriptomics</div>
+      <div style="margin-top:10px;">
+        ${gene.expression_pattern
+          ? `<div style="display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:999px;background:#eef2ef;font-weight:800;font-size:13px;color:var(--mob-ink);">
+               <span style="width:8px;height:8px;border-radius:50%;background:var(--mob-green);"></span>
+               ${esc(gene.expression_pattern)}
+             </div>`
+          : `<div style="font-style:italic;color:var(--mob-ink-3);font-size:14px;">No expression data</div>`}
+      </div>
+    </div>
+
+    <div class="mob-card">
+      <div class="mob-card-h">EB / RB Proteomics</div>
+      <div id="mob-proteomics-inner" style="margin-top:12px;font-style:italic;color:var(--mob-ink-3);font-size:14px;">Loading…</div>
+    </div>
+
+    <div class="mob-pad-bottom"></div>`;
+
+  scroll.querySelector('.mob-fav-btn')?.addEventListener('click', async (e) => {
+    e.stopPropagation();
+    const btn = e.currentTarget;
+    await toggleFavoriteDB('gene', gene.id);
+    const nowFav = state.favorites.genes.has(String(gene.id));
+    btn.classList.toggle('saved-on', nowFav);
+    const svg = btn.querySelector('svg');
+    if (svg) { svg.setAttribute('fill', nowFav ? '#e8b400' : 'none'); svg.setAttribute('stroke', nowFav ? '#e8b400' : 'currentColor'); }
+    if (nowFav) btn.classList.add('mob-star-pop');
+    btn.addEventListener('animationend', () => btn.classList.remove('mob-star-pop'), { once: true });
+  });
+
+  if (gene.id) {
+    sb.from('proteins')
+      .select('mass_kd,length_aa,transmembrane_domains,signal_peptide')
+      .eq('gene_id', gene.id)
+      .maybeSingle()
+      .then(({ data: p }) => {
+        const kvEl = scroll.querySelector('#mob-protein-kv');
+        if (kvEl && p) {
+          kvEl.innerHTML = `
+            <div class="mob-kv"><div class="mob-k">Mass</div><div class="mob-v sm">${p.mass_kd ? p.mass_kd.toFixed(1) + ' kDa' : '—'}</div></div>
+            <div class="mob-kv"><div class="mob-k">Length</div><div class="mob-v sm">${p.length_aa ? p.length_aa.toLocaleString() + ' aa' : '—'}</div></div>
+            <div class="mob-kv"><div class="mob-k">TM domains</div><div class="mob-v sm">${p.transmembrane_domains ?? '0'}</div></div>
+            <div class="mob-kv"><div class="mob-k">Signal peptide</div><div class="mob-v sm">${p.signal_peptide ? 'Yes' : 'No'}</div></div>`;
+        }
+      });
+
+    sb.from('proteins')
+      .select('eb_enriched,rb_enriched')
+      .eq('gene_id', gene.id)
+      .maybeSingle()
+      .then(({ data: p }) => {
+        const el = scroll.querySelector('#mob-proteomics-inner');
+        if (!el) return;
+        if (!p || (p.eb_enriched == null && p.rb_enriched == null)) {
+          el.textContent = 'No proteomic data available';
+        } else {
+          el.innerHTML = `
+            <div class="mob-kv-grid">
+              <div class="mob-kv"><div class="mob-k">EB enriched</div><div class="mob-v sm">${p.eb_enriched ? 'Yes' : 'No'}</div></div>
+              <div class="mob-kv"><div class="mob-k">RB enriched</div><div class="mob-v sm">${p.rb_enriched ? 'Yes' : 'No'}</div></div>
+            </div>`;
+        }
+      });
+  }
+
+  _buildMobGenomicContext(gene, scroll.querySelector('#mob-ctx-inner'));
+}
+
+async function _buildMobGenomicContext(gene, inner) {
+  if (!inner || !gene.strain_id || gene.sort_index == null) {
+    if (inner) inner.innerHTML = '<div style="color:var(--mob-ink-3);font-size:13px;padding:10px 0;">Context unavailable</div>';
+    return;
+  }
+
+  const { data: neighbors } = await sb
+    .from('genes')
+    .select('id,locus_tag,gene_name,gene_symbol,functional_category,strand,start_bp,end_bp,sort_index')
+    .eq('strain_id', gene.strain_id)
+    .gte('sort_index', gene.sort_index - 5)
+    .lte('sort_index', gene.sort_index + 5)
+    .order('sort_index');
+
+  if (!neighbors || neighbors.length === 0) {
+    inner.innerHTML = '<div style="color:var(--mob-ink-3);font-size:13px;padding:10px 0;">No neighbors found</div>';
+    return;
+  }
+
+  const cols = neighbors.map(g => {
+    const isFocal = String(g.id) === String(gene.id);
+    const col     = CATEGORY_COLORS[g.functional_category] ?? CATEGORY_COLOR_DEFAULT;
+    const bp      = (g.end_bp ?? 0) - (g.start_bp ?? 0);
+    const width   = Math.max(72, Math.min(150, bp * 0.05)) + 'px';
+    const isPlus  = g.strand === '+' || g.strand === '1' || g.strand === 1;
+    const sym     = g.gene_symbol || g.gene_name || g.locus_tag.slice(-6);
+    const opacity = isFocal ? '1' : '0.82';
+
+    const plusArrow  = isPlus  ? `<div class="mob-ctx-arrow plus"  style="width:${width};"><div class="body" style="background:${col};opacity:${opacity};"></div></div>` : '';
+    const minusArrow = !isPlus ? `<div class="mob-ctx-arrow minus" style="width:${width};"><div class="body" style="background:${col};opacity:${opacity};"></div></div>` : '';
+
+    return `
+      <div class="mob-ctx-col${isFocal ? ' focal' : ''}" ${isFocal ? 'data-focal="1"' : ''}>
+        <div class="mob-ctx-lab">${isPlus ? `<span class="sym">${sym}</span>` : ''}</div>
+        <div class="mob-ctx-arrow-slot plus">${plusArrow}</div>
+        <div class="mob-ctx-center"></div>
+        <div class="mob-ctx-arrow-slot minus">${minusArrow}</div>
+        <div class="mob-ctx-lab mono">${!isPlus ? `<span class="sym">${sym}</span>` : ''}</div>
+      </div>`;
+  }).join('');
+
+  inner.innerHTML = `
+    <div class="mob-ctx-wrap">
+      <div class="mob-ctx-scroll" id="mob-ctx-scr">
+        <div class="mob-ctx-track">
+          <div class="mob-ctx-strand p">+</div>
+          <div class="mob-ctx-strand m">−</div>
+          ${cols}
+        </div>
+      </div>
+      <div class="mob-ctx-fade l"></div>
+      <div class="mob-ctx-fade r"></div>
+      <div class="mob-ctx-hint" id="mob-ctx-hint">↔ swipe</div>
+    </div>`;
+
+  const scr   = inner.querySelector('#mob-ctx-scr');
+  const focal = inner.querySelector('[data-focal]');
+  if (scr && focal) {
+    const doCenter = () => {
+      scr.scrollLeft = focal.offsetLeft - (scr.clientWidth - focal.offsetWidth) / 2;
+    };
+    requestAnimationFrame(doCenter);
+    setTimeout(doCenter, 140);
+
+    const hint = inner.querySelector('#mob-ctx-hint');
+    if (hint) scr.addEventListener('scroll', () => { hint.style.opacity = '0'; }, { once: true, passive: true });
+  }
 }
 
 const CATEGORY_OPTIONS = Object.keys(CATEGORY_COLORS);

--- a/web/js/views/genomes.js
+++ b/web/js/views/genomes.js
@@ -214,23 +214,7 @@ function _renderMobileGeneList(container) {
           placeholder="Search genes, locus, products…" />
         <button id="mob-gene-search-clear" style="display:none;background:none;border:none;color:var(--mob-ink-3);cursor:pointer;padding:0;font-size:14px;">✕</button>
       </div>
-      <div class="mob-chip-row" style="padding:0;">
-        <div class="mob-seg" id="mob-gene-sort">
-          <button class="mob-seg-btn active" data-sort="locus_tag">Locus</button>
-          <button class="mob-seg-btn" data-sort="gene_name">A–Z</button>
-          <button class="mob-seg-btn" data-sort="functional_category">Function</button>
-        </div>
-        <div style="width:.5px;background:var(--mob-line);margin:6px 0;flex-shrink:0;"></div>
-        <button class="mob-chip active" data-filter="all">All</button>
-        <button class="mob-chip" data-filter="characterized">Characterized</button>
-        <button class="mob-chip" data-filter="inc">
-          <span class="mob-dot" style="background:#E4B47E;"></span>Inc
-        </button>
-        <button class="mob-chip" data-filter="secreted">
-          <span class="mob-dot" style="background:#00A551;"></span>Secreted
-        </button>
-        <button class="mob-chip" data-filter="hypothetical">Hypothetical</button>
-      </div>
+      <div id="filter-bar" style="flex-shrink:0;"></div>
     </div>
 
     <div id="mob-gene-list" style="background:var(--mob-bg);"></div>
@@ -254,33 +238,12 @@ function _renderMobileGeneList(container) {
     _offset = 0; _mobFetchGenes(container);
   });
 
-  container.querySelectorAll('#mob-gene-sort .mob-seg-btn').forEach(btn => {
-    btn.addEventListener('click', () => {
-      container.querySelectorAll('#mob-gene-sort .mob-seg-btn').forEach(b => b.classList.remove('active'));
-      btn.classList.add('active');
-      _sortField = btn.dataset.sort;
-      _sortAsc   = true;
-      _offset    = 0;
-      _mobFetchGenes(container);
-    });
-  });
+  const mobFetchFn = c => _mobFetchGenes(c);
+  renderFilterBar(container, false, mobFetchFn);
 
-  container.querySelectorAll('.mob-chip[data-filter]').forEach(chip => {
-    chip.addEventListener('click', () => {
-      container.querySelectorAll('.mob-chip[data-filter]').forEach(c => c.classList.remove('active'));
-      chip.classList.add('active');
-      const f = chip.dataset.filter;
-      _filters = { favorites: false, characterized: false, hypothetical: false,
-                   inc: false, membrane: false, secreted: false, dnaBinding: false,
-                   hasAf3: false, hasCrystal: false };
-      if (f === 'characterized') _filters.characterized = true;
-      if (f === 'inc')           _filters.inc           = true;
-      if (f === 'secreted')      _filters.secreted      = true;
-      if (f === 'hypothetical')  _filters.hypothetical  = true;
-      _categoryFilter = null;
-      _offset = 0;
-      _mobFetchGenes(container);
-    });
+  // Dismiss sort dropdown on outside click (same as desktop)
+  document.addEventListener('click', () => {
+    container.querySelector('#sort-dropdown')?.style.setProperty('display', 'none');
   });
 
   container.querySelector('#mob-strain-switch-btn').addEventListener('click', () => {
@@ -301,15 +264,23 @@ async function _mobFetchGenes(container) {
     list.innerHTML = '<div style="padding:24px 20px;color:var(--mob-ink-3);font-size:14px;">Loading…</div>';
   }
 
+  const structFilterActive = _filters.hasAf3 || _filters.hasCrystal;
+  const proteinsJoin = structFilterActive
+    ? 'proteins!inner(has_af3_structure,has_crystal_structure,' +
+      'subcellular_location_sl,subcellular_location_go,alphafold_results(thumbnail_path))'
+    : 'proteins(has_af3_structure,has_crystal_structure,' +
+      'subcellular_location_sl,subcellular_location_go,alphafold_results(thumbnail_path))';
+
   let query = sb
     .from('genes')
     .select(
       'id,locus_tag,gene_name,gene_symbol,product,functional_category,' +
       'is_characterized,is_hypothetical,is_t3_secreted,is_membrane_protein,' +
+      'is_dna_binding,eb_enriched,rb_enriched,expression_pattern,' +
       'sort_index,strand,start_bp,end_bp,strain_id,updated_at,updated_by,' +
       'dna_sequence,' +
       'strains!inner(common_name),' +
-      'proteins(alphafold_results(thumbnail_path))',
+      proteinsJoin,
       { count: 'exact' }
     )
     .eq('strains.common_name', _strain)
@@ -322,11 +293,25 @@ async function _mobFetchGenes(container) {
       `gene_symbol.ilike.%${_search}%,product.ilike.%${_search}%`
     );
   }
-  if (_filters.characterized) query = query.eq('is_characterized', true);
-  if (_filters.hypothetical)  query = query.eq('is_hypothetical',  true);
-  if (_filters.inc)           query = query.eq('functional_category', 'Inclusion membrane protein');
-  if (_filters.secreted)      query = query.eq('is_t3_secreted', true);
-  if (_categoryFilter)        query = query.eq('functional_category', _categoryFilter);
+  if (_filters.characterized)  query = query.eq('is_characterized', true);
+  if (_filters.hypothetical)   query = query.eq('is_hypothetical',  true);
+  if (_filters.inc)            query = query.eq('functional_category', 'Inclusion membrane protein');
+  if (_filters.membrane)       query = query.eq('is_membrane_protein', true);
+  if (_filters.secreted)       query = query.eq('is_t3_secreted', true);
+  if (_filters.dnaBinding)     query = query.eq('is_dna_binding', true);
+  if (_filters.hasAf3)         query = query.eq('proteins.has_af3_structure', true);
+  if (_filters.hasCrystal)     query = query.eq('proteins.has_crystal_structure', true);
+  if (_categoryFilter)         query = query.eq('functional_category', _categoryFilter);
+  if (_expressionFilter)       query = query.eq('expression_pattern', _expressionFilter);
+  if (_ebRbFilter === 'eb')    query = query.eq('eb_enriched', true);
+  if (_ebRbFilter === 'rb')    query = query.eq('rb_enriched', true);
+  if (_locationFilter) {
+    if (_locationFilter.startsWith('GO:')) {
+      query = query.filter('proteins.subcellular_location_go', 'cs', `{${_locationFilter}}`);
+    } else {
+      query = query.filter('proteins.subcellular_location_sl', 'cs', `{${_locationFilter}}`);
+    }
+  }
 
   let data, count;
   try {
@@ -348,11 +333,16 @@ async function _mobFetchGenes(container) {
   _hasMore = _offset + data.length < _total;
   _offset += data.length;
 
+  // Apply favorites filter client-side
+  const rows = _filters.favorites
+    ? data.filter(g => state.favorites.genes.has(String(g.id)))
+    : data;
+
   const countEl = container.querySelector('#mob-gene-count');
   if (countEl) countEl.textContent = `${_total.toLocaleString()} genes`;
 
   const isFirstPage = (_offset - data.length) === 0;
-  const html = _mobGroupAndRenderGenes(data);
+  const html = _mobGroupAndRenderGenes(rows);
   if (isFirstPage) {
     list.innerHTML = html || '<div style="padding:24px 20px;color:var(--mob-ink-3);font-size:14px;text-align:center;">No genes found.</div>';
   } else {
@@ -673,7 +663,8 @@ const SORT_OPTIONS = [
   { field: 'sort_index', asc: true,  label: 'Genomic order' },
 ];
 
-function renderFilterBar(container, expandMore = false) {
+function renderFilterBar(container, expandMore = false, fetchFn = null) {
+  const doFetch = fetchFn ?? ((c) => fetchGenes(c, true));
   const bar = container.querySelector('#filter-bar');
   if (!bar) return;
 
@@ -827,8 +818,8 @@ function renderFilterBar(container, expandMore = false) {
       _sortField = btn.dataset.sortField;
       _sortAsc   = btn.dataset.sortAsc === 'true';
       _offset = 0;
-      renderFilterBar(container);
-      fetchGenes(container, true);
+      renderFilterBar(container, false, doFetch);
+      doFetch(container);
     });
   });
 
@@ -837,7 +828,7 @@ function renderFilterBar(container, expandMore = false) {
     btn.addEventListener('click', () => {
       const id = btn.dataset.section;
       _expandedSections[id] = !secOpen[id];
-      renderFilterBar(container, true);
+      renderFilterBar(container, true, doFetch);
     });
   });
 
@@ -847,8 +838,8 @@ function renderFilterBar(container, expandMore = false) {
       const key = btn.dataset.filter;
       _filters[key] = !_filters[key];
       _offset = 0;
-      renderFilterBar(container, startOpen);
-      fetchGenes(container, true);
+      renderFilterBar(container, startOpen, doFetch);
+      doFetch(container);
     });
   });
 
@@ -858,8 +849,8 @@ function renderFilterBar(container, expandMore = false) {
       const val = btn.dataset.catFilter;
       _categoryFilter = _categoryFilter === val ? null : val;
       _offset = 0;
-      renderFilterBar(container, true);
-      fetchGenes(container, true);
+      renderFilterBar(container, true, doFetch);
+      doFetch(container);
     });
   });
 
@@ -867,8 +858,8 @@ function renderFilterBar(container, expandMore = false) {
   bar.querySelector('[data-clear-category]')?.addEventListener('click', () => {
     _categoryFilter = null;
     _offset = 0;
-    renderFilterBar(container);
-    fetchGenes(container, true);
+    renderFilterBar(container, false, doFetch);
+    doFetch(container);
   });
 
   // Clear location filter (appears in both main bar and More panel)
@@ -876,8 +867,8 @@ function renderFilterBar(container, expandMore = false) {
     btn.addEventListener('click', () => {
       _locationFilter = null;
       _offset = 0;
-      renderFilterBar(container);
-      fetchGenes(container, true);
+      renderFilterBar(container, false, doFetch);
+      doFetch(container);
     });
   });
 
@@ -887,8 +878,8 @@ function renderFilterBar(container, expandMore = false) {
       const val = btn.dataset.exprFilter;
       _expressionFilter = _expressionFilter === val ? null : val;
       _offset = 0;
-      renderFilterBar(container, true);
-      fetchGenes(container, true);
+      renderFilterBar(container, true, doFetch);
+      doFetch(container);
     });
   });
 
@@ -896,8 +887,8 @@ function renderFilterBar(container, expandMore = false) {
   bar.querySelector('[data-clear-expression]')?.addEventListener('click', () => {
     _expressionFilter = null;
     _offset = 0;
-    renderFilterBar(container);
-    fetchGenes(container, true);
+    renderFilterBar(container, false, doFetch);
+    doFetch(container);
   });
 
   // EB/RB proteomics filter chips
@@ -906,8 +897,8 @@ function renderFilterBar(container, expandMore = false) {
       const val = btn.dataset.ebrbFilter;
       _ebRbFilter = _ebRbFilter === val ? null : val;
       _offset = 0;
-      renderFilterBar(container, true);
-      fetchGenes(container, true);
+      renderFilterBar(container, true, doFetch);
+      doFetch(container);
     });
   });
 
@@ -915,8 +906,8 @@ function renderFilterBar(container, expandMore = false) {
   bar.querySelector('[data-clear-ebrb]')?.addEventListener('click', () => {
     _ebRbFilter = null;
     _offset = 0;
-    renderFilterBar(container);
-    fetchGenes(container, true);
+    renderFilterBar(container, false, doFetch);
+    doFetch(container);
   });
 
   // More panel toggle

--- a/web/js/views/genomes.js
+++ b/web/js/views/genomes.js
@@ -834,11 +834,11 @@ function renderFilterBar(container, expandMore = false, fetchFn = null, opts = {
       </button>
     </div>
     <div id="more-panel" style="display:${startOpen ? 'block' : 'none'};padding:4px 12px 8px;background:#fafafa;border-bottom:1px solid #f0f0f0;overflow-y:auto;max-height:calc(100vh - 200px);">
-      ${groupHead('characterization', '', 'Characterization', secOpen.characterization)}
+      ${groupHead('characterization', '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z"/><circle cx="7.5" cy="7.5" r=".5" fill="currentColor"/></svg>', 'Characterization', secOpen.characterization)}
       <div style="display:${secOpen.characterization ? 'flex' : 'none'};flex-wrap:wrap;gap:5px;padding-bottom:4px;">
         ${CHAR_FILTERS.map(f => chip(f.id, f.label, _filters[f.id])).join('')}
       </div>
-      ${groupHead('function', '⚙️', 'Function', secOpen.function, '— filter by role')}
+      ${groupHead('function', '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 10.27 7 3.34"/><path d="m11 13.73-4 6.93"/><path d="M12 22v-2"/><path d="M12 2v2"/><path d="M14 12h8"/><path d="m17 20.66-1-1.73"/><path d="m17 3.34-1 1.73"/><path d="M2 12h2"/><path d="m20.66 17-1.73-1"/><path d="m20.66 7-1.73 1"/><path d="m3.34 17 1.73-1"/><path d="m3.34 7 1.73 1"/><circle cx="12" cy="12" r="2"/><circle cx="12" cy="12" r="8"/></svg>', 'Function', secOpen.function, '— filter by role')}
       <div style="display:${secOpen.function ? 'flex' : 'none'};flex-wrap:wrap;gap:5px;padding-bottom:4px;">
         ${FUNC_FILTERS.map(f => catChip(f.value, f.label)).join('')}
       </div>
@@ -849,17 +849,17 @@ function renderFilterBar(container, expandMore = false, fetchFn = null, opts = {
           ? `<button data-clear-location style="font-size:10.5px;font-weight:600;padding:3px 9px;border-radius:20px;border:1px solid #bfdbfe;background:#eff6ff;color:#1d4ed8;cursor:pointer;white-space:nowrap;font-family:inherit;">📍 ${esc(locTermLabel(_locationFilter))} ×</button>`
           : `<span style="font-size:9px;color:#bbb;padding:2px 0;">Click a location pill on any gene to filter</span>`}
       </div>` : ''}
-      ${groupHead('structure', '🧊', 'Structure', secOpen.structure)}
+      ${groupHead('structure', '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/></svg>', 'Structure', secOpen.structure)}
       <div style="display:${secOpen.structure ? 'flex' : 'none'};flex-wrap:wrap;gap:5px;padding-bottom:4px;">
         ${STRUCT_FILTERS.map(f => chip(f.id, f.label, _filters[f.id], f.title)).join('')}
       </div>
-      ${groupHead('expression', '📈', 'Expression', secOpen.expression, '— click chart or peak label on any gene')}
+      ${groupHead('expression', '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v16a2 2 0 0 0 2 2h16"/><path d="m19 9-5 5-4-4-3 3"/></svg>', 'Expression', secOpen.expression, '— click chart or peak label on any gene')}
       <div style="display:${secOpen.expression ? 'flex' : 'none'};flex-wrap:wrap;gap:5px;padding-bottom:4px;">
         ${EXPR_FILTERS.map(f => exprChip(f.value, f.label)).join('')}
-        ${_strain === 'CT-L2' ? ebRbChip('eb', 'EB enriched') + ebRbChip('rb', 'RB enriched') : ''}
+        ${_strain === 'CT-L2' ? `<div style="display:flex;gap:5px;">${ebRbChip('eb', 'EB enriched')}${ebRbChip('rb', 'RB enriched')}</div>` : ''}
       </div>
       ${mutantFilters.length ? `
-      ${groupHead('mutants', '🔬', 'Mutants', secOpen.mutants, '— genes with this mutant type')}
+      ${groupHead('mutants', '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z"/></svg>', 'Mutants', secOpen.mutants, '— genes with this mutant type')}
       <div style="display:${secOpen.mutants ? 'flex' : 'none'};flex-wrap:wrap;gap:5px;padding-bottom:4px;">
         ${mutantFilters.map(f => mutantChip(f)).join('')}
       </div>` : ''}

--- a/web/js/views/genomes.js
+++ b/web/js/views/genomes.js
@@ -184,11 +184,6 @@ function _renderMobileGeneList(container) {
 
   container.style.padding = '0';
   container.innerHTML = `
-    <div class="mob-lt-wrap" style="padding-top:8px;">
-      <div class="mob-lt-eyebrow">Genomes</div>
-      <h1 class="mob-lt-title">${_strain}</h1>
-    </div>
-
     <div class="mob-strain-ctx">
       <img src="${currentStrain.icon}" alt="${currentStrain.id}" onerror="this.style.display='none'">
       <div style="flex:1;min-width:0;">
@@ -353,11 +348,28 @@ async function _mobFetchGenes(container) {
 
   list.querySelectorAll('.mob-grow:not([data-wired])').forEach(row => {
     row.dataset.wired = '1';
-    row.addEventListener('click', () => {
+    row.addEventListener('click', e => {
+      if (e.target.closest('.mob-star')) return; // handled by delegation below
       const gene = _geneCache.get(row.dataset.id);
       if (gene) showGeneDetailMobile(gene, container);
     });
   });
+
+  // Star toggle delegation — wire once on the list container
+  if (!list.dataset.starWired) {
+    list.dataset.starWired = '1';
+    list.addEventListener('click', async e => {
+      const starBtn = e.target.closest('.mob-star');
+      if (!starBtn) return;
+      e.stopPropagation();
+      if (!state.user) { window.__showAuthModal?.('signin'); return; }
+      const geneId = starBtn.dataset.favId;
+      const nowFav = await toggleFavoriteDB('gene', geneId);
+      starBtn.classList.toggle('on', nowFav);
+      const svg = starBtn.querySelector('svg');
+      if (svg) { svg.setAttribute('fill', nowFav ? '#e8b400' : 'none'); svg.setAttribute('stroke', nowFav ? '#e8b400' : 'currentColor'); }
+    });
+  }
 
   _mobSetupInfiniteScroll(container);
 }
@@ -365,12 +377,18 @@ async function _mobFetchGenes(container) {
 function _mobGroupAndRenderGenes(genes) {
   if (!genes.length) return '';
 
+  // Locus-tag sort: no section headers (they'd just be uninformative "CTL0___" labels)
+  if (_sortField === 'locus_tag') {
+    return `<div style="background:var(--mob-paper);">
+      ${genes.map((g, i) => _mobGeneRow(g, i < genes.length - 1)).join('')}
+    </div>`;
+  }
+
   const groups = new Map();
   genes.forEach(g => {
     let key;
     if (_sortField === 'functional_category') key = g.functional_category ?? 'Unknown';
-    else if (_sortField === 'gene_name') key = g.gene_name ? g.gene_name[0].toUpperCase() : '#';
-    else key = g.locus_tag.slice(0, -3) + '___';
+    else key = g.gene_name ? g.gene_name[0].toUpperCase() : '#';
     if (!groups.has(key)) groups.set(key, []);
     groups.get(key).push(g);
   });

--- a/web/js/views/home.js
+++ b/web/js/views/home.js
@@ -85,18 +85,14 @@ async function renderHomeMobile(container) {
       </div>
 
       <div class="mob-home-sec-h">
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"
-          style="color:var(--mob-green-ink)"><path d="M8 2C8 5 16 7 16 10C16 13 8 15 8 18C8 21 16 22 16 22"/>
-          <path d="M16 2C16 5 8 7 8 10C8 13 16 15 16 18C16 21 8 22 8 22"/>
-          <line x1="8" y1="2" x2="16" y2="2"/><line x1="8" y1="22" x2="16" y2="22"/></svg>
+        <img src="/design/icons_mobile/dna.png" class="mob-sec-icon" alt="">
         <span class="t">Genomes</span>
         <span style="margin-left:auto;font-size:12px;color:var(--mob-ink-3);font-family:var(--mob-mono);">tap to browse</span>
       </div>
       <div id="mob-home-strain-cards"></div>
 
       <div class="mob-home-sec-h">
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"
-          style="color:var(--mob-green-ink)"><path d="M13 2L4.5 13H11L10 22L19.5 11H13L13 2Z"/></svg>
+        <img src="/design/icons_mobile/bolt.png" class="mob-sec-icon" alt="">
         <span class="t">Mutants</span>
         <span style="margin-left:auto;font-size:12px;color:var(--mob-ink-3);font-family:var(--mob-mono);">tap to browse</span>
       </div>

--- a/web/js/views/home.js
+++ b/web/js/views/home.js
@@ -112,6 +112,43 @@ async function renderHomeMobile(container) {
         <div id="mob-leaflet-map" style="width:100%;height:100%;"></div>
       </div>
 
+      <!-- Community stats -->
+      <div style="display:flex;gap:8px;margin:10px 16px 0;">
+        <div class="mob-hstat" style="flex:1;">
+          <div class="n" style="font-size:22px;" id="mob-stat-users">—</div>
+          <div class="l">Users</div>
+        </div>
+        <div class="mob-hstat" style="flex:1;">
+          <div class="n" style="font-size:22px;" id="mob-stat-annotations">—</div>
+          <div class="l">Annotations</div>
+        </div>
+      </div>
+
+      <!-- Footer -->
+      <div style="margin:24px 16px 0;padding:16px 0;border-top:.5px solid var(--mob-line);">
+        <div style="font-family:var(--mob-sans);font-size:13px;font-weight:700;color:var(--mob-ink);">Hybiske Lab</div>
+        <div style="font-size:12px;color:var(--mob-ink-3);margin-top:2px;">University of Washington · Seattle, WA</div>
+        <div style="display:flex;gap:16px;margin-top:10px;">
+          <button id="mob-cite-btn" style="font-size:12.5px;color:var(--mob-green);background:none;border:none;cursor:pointer;padding:0;font-family:var(--mob-sans);font-weight:600;">How to cite</button>
+          <a href="https://github.com/khybiske/ChlamAtlas" target="_blank" rel="noopener" style="font-size:12.5px;color:var(--mob-green);text-decoration:none;font-weight:600;">GitHub</a>
+          <a href="mailto:khybiske@uw.edu" style="font-size:12.5px;color:var(--mob-green);text-decoration:none;font-weight:600;">Contact</a>
+        </div>
+      </div>
+
+      <!-- Citation modal (shared with desktop) -->
+      <div id="mob-citation-modal" style="display:none;position:fixed;inset:0;z-index:200;background:rgba(0,0,0,.5);backdrop-filter:blur(4px);align-items:center;justify-content:center;">
+        <div style="background:#fff;border-radius:18px;width:calc(100% - 32px);max-width:360px;overflow:hidden;box-shadow:0 20px 60px rgba(0,0,0,.25);">
+          <div style="padding:16px 20px 14px;background:#163b2b;">
+            <div style="font-family:var(--mob-serif);font-weight:700;font-size:20px;color:#fff;">How to cite</div>
+          </div>
+          <div style="padding:16px 20px;">
+            <p id="mob-citation-text" style="font-family:var(--mob-mono);font-size:12px;line-height:1.6;color:#333;background:#f9f9f9;border-radius:8px;padding:12px;margin:0 0 14px;white-space:pre-wrap;">Hybiske et al., manuscript in preparation.</p>
+            <button id="mob-citation-copy" style="width:100%;background:#163b2b;color:#fff;border:none;border-radius:10px;padding:11px;font-size:14px;font-weight:600;cursor:pointer;margin-bottom:8px;">Copy citation</button>
+            <button id="mob-citation-close" style="width:100%;background:none;border:none;color:#9ca3af;font-size:13px;cursor:pointer;padding:4px;">Close</button>
+          </div>
+        </div>
+      </div>
+
       <div class="mob-pad-bottom"></div>
     </div>`;
 
@@ -147,22 +184,23 @@ async function renderHomeMobile(container) {
   };
   const chevron = `<svg style="margin-left:auto;flex-shrink:0;color:#c8cec9" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><polyline points="9 18 15 12 9 6"/></svg>`;
 
+  // Italicize only the genus+species part (e.g. "C. trachomatis"), not the strain suffix
+  const italicSpecies = (sp) => sp.replace(/^([A-Z]\.\s+\w+)/, '<em>$1</em>');
+
   const strainCards = container.querySelector('#mob-home-strain-cards');
   if (strainCards && strainRes.data) {
     strainCards.innerHTML = strainRes.data.map(s => {
-      const color   = strainColors[s.common_name] ?? '#2f9e6e';
       const icon    = strainIcons[s.common_name]  ?? '';
       const species = strainSpecies[s.common_name] ?? '';
       const gCount  = s.genes?.[0]?.count ?? '—';
       return `
         <div class="mob-strain-card" data-strain="${esc(s.common_name)}">
-          <div class="sbar" style="background:${color};"></div>
-          <img class="sicon" src="${esc(icon)}" alt="${esc(s.common_name)}" onerror="this.style.display='none'">
+          <img class="sicon" src="${esc(icon)}" alt="${esc(s.common_name)}" onerror="this.style.display='none'" style="margin-left:14px;">
           <div style="flex:1;min-width:0;">
-            <div style="font-style:italic;font-size:15px;color:var(--mob-ink);font-weight:500;margin-bottom:3px;"><em>${esc(species)}</em></div>
+            <div style="font-size:15px;color:var(--mob-ink);font-weight:500;margin-bottom:3px;">${italicSpecies(esc(species))}</div>
             <div style="display:flex;align-items:center;gap:5px;">
-              <span class="scode" style="color:${color};font-size:13px;">${esc(s.common_name)}</span>
-              <span class="scount" style="margin-top:0;">· ${Number(gCount).toLocaleString()} genes</span>
+              <span style="font-weight:700;font-size:13px;color:var(--mob-ink-2);">${esc(s.common_name)}</span>
+              <span style="font-size:12.5px;color:var(--mob-ink-3);">· ${Number(gCount).toLocaleString()} genes</span>
             </div>
           </div>
           ${chevron}
@@ -187,11 +225,13 @@ async function renderHomeMobile(container) {
   if (collRows) {
     collRows.innerHTML = COLLECTIONS_MOBILE.map(c => {
       const n = mutantCounts[c.id] ?? 0;
+      // Italicize genus+species labels (C. trachomatis, C. muridarum)
+      const labelHtml = c.label.match(/^[A-Z]\./) ? `<em>${esc(c.label)}</em>` : esc(c.label);
       return `
         <div class="mob-minirow" data-collection="${esc(c.id)}">
           <img src="${esc(c.icon)}" alt="${esc(c.label)}" style="width:34px;height:34px;object-fit:contain;flex-shrink:0;" onerror="this.style.display='none'">
           <div style="flex:1;min-width:0;">
-            <div class="mn">${esc(c.label)}</div>
+            <div class="mn">${labelHtml}</div>
             <div class="ms">${esc(c.sub)} · ${n} mutants</div>
           </div>
           ${chevron}
@@ -205,6 +245,37 @@ async function renderHomeMobile(container) {
       });
     });
   }
+
+  // Wire footer citation modal
+  const citeBtn   = container.querySelector('#mob-cite-btn');
+  const citeModal = container.querySelector('#mob-citation-modal');
+  const citeCopy  = container.querySelector('#mob-citation-copy');
+  const citeClose = container.querySelector('#mob-citation-close');
+  const citeText  = container.querySelector('#mob-citation-text');
+  if (citeBtn && citeModal) {
+    citeBtn.addEventListener('click', () => { citeModal.style.display = 'flex'; });
+    citeClose.addEventListener('click', () => { citeModal.style.display = 'none'; });
+    citeModal.addEventListener('click', (e) => { if (e.target === citeModal) citeModal.style.display = 'none'; });
+    // Load citation text
+    sb.from('site_config').select('value').eq('key','citation').maybeSingle().then(({ data }) => {
+      if (data?.value && citeText) citeText.textContent = data.value;
+    });
+    citeCopy?.addEventListener('click', async () => {
+      try { await navigator.clipboard.writeText(citeText?.textContent ?? ''); citeCopy.textContent = 'Copied!'; }
+      catch { citeCopy.textContent = 'Copy failed'; }
+      setTimeout(() => { citeCopy.textContent = 'Copy citation'; }, 2000);
+    });
+  }
+
+  // Fetch community stats
+  sb.from('users').select('id', { count: 'exact', head: true }).then(({ count }) => {
+    const el = container.querySelector('#mob-stat-users');
+    if (el) el.textContent = (count ?? 0).toLocaleString();
+  });
+  sb.from('annotations').select('id', { count: 'exact', head: true }).then(({ count }) => {
+    const el = container.querySelector('#mob-stat-annotations');
+    if (el) el.textContent = (count ?? 0).toLocaleString();
+  });
 
   // Community map
   const mapEl = container.querySelector('#mob-leaflet-map');

--- a/web/js/views/home.js
+++ b/web/js/views/home.js
@@ -85,14 +85,19 @@ async function renderHomeMobile(container) {
       </div>
 
       <div class="mob-home-sec-h">
-        <img src="/design/icons_mobile/dna.png" class="mob-sec-icon" alt="">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" style="color:var(--mob-green-ink);flex-shrink:0;">
+          <path d="M5.5 3c0 5 5 5.5 6.5 8.5S18.5 16 18.5 21"/><path d="M18.5 3c0 5-5 5.5-6.5 8.5S5.5 16 5.5 21"/>
+          <line x1="5.5" y1="8" x2="18.5" y2="8"/><line x1="5.5" y1="16" x2="18.5" y2="16"/>
+        </svg>
         <span class="t">Genomes</span>
         <span style="margin-left:auto;font-size:12px;color:var(--mob-ink-3);font-family:var(--mob-mono);">tap to browse</span>
       </div>
       <div id="mob-home-strain-cards"></div>
 
       <div class="mob-home-sec-h">
-        <img src="/design/icons_mobile/bolt.png" class="mob-sec-icon" alt="">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" stroke="none" style="color:var(--mob-green-ink);flex-shrink:0;">
+          <path d="M13 2L4.5 13.5H11l-1 8.5L20.5 10H14z"/>
+        </svg>
         <span class="t">Mutants</span>
         <span style="margin-left:auto;font-size:12px;color:var(--mob-ink-3);font-family:var(--mob-mono);">tap to browse</span>
       </div>

--- a/web/js/views/home.js
+++ b/web/js/views/home.js
@@ -85,28 +85,21 @@ async function renderHomeMobile(container) {
       </div>
 
       <div class="mob-home-sec-h">
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" style="color:var(--mob-green-ink);flex-shrink:0;">
-          <path d="M5.5 3c0 5 5 5.5 6.5 8.5S18.5 16 18.5 21"/><path d="M18.5 3c0 5-5 5.5-6.5 8.5S5.5 16 5.5 21"/>
-          <line x1="5.5" y1="8" x2="18.5" y2="8"/><line x1="5.5" y1="16" x2="18.5" y2="16"/>
-        </svg>
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--mob-green-ink);flex-shrink:0;"><path d="m10 16 1.5 1.5"/><path d="m14 8-1.5-1.5"/><path d="M15 2c-1.798 1.998-2.518 3.995-2.807 5.993"/><path d="m16.5 10.5 1 1"/><path d="m17 6-2.891-2.891"/><path d="M2 15c6.667-6 13.333 0 20-6"/><path d="m20 9 .891.891"/><path d="M3.109 14.109 4 15"/><path d="m6.5 12.5 1 1"/><path d="m7 18 2.891 2.891"/><path d="M9 22c1.798-1.998 2.518-3.995 2.807-5.993"/></svg>
         <span class="t">Genomes</span>
         <span style="margin-left:auto;font-size:12px;color:var(--mob-ink-3);font-family:var(--mob-mono);">tap to browse</span>
       </div>
       <div id="mob-home-strain-cards"></div>
 
       <div class="mob-home-sec-h">
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" stroke="none" style="color:var(--mob-green-ink);flex-shrink:0;">
-          <path d="M13 2L4.5 13.5H11l-1 8.5L20.5 10H14z"/>
-        </svg>
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--mob-green-ink);flex-shrink:0;"><path d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z"/></svg>
         <span class="t">Mutants</span>
         <span style="margin-left:auto;font-size:12px;color:var(--mob-ink-3);font-family:var(--mob-mono);">tap to browse</span>
       </div>
       <div id="mob-home-collection-rows"></div>
 
       <div class="mob-home-sec-h">
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"
-          style="color:var(--mob-green-ink)"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
-          <circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--mob-green-ink);flex-shrink:0;"><circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/><path d="M2 12h20"/></svg>
         <span class="t">Community</span>
       </div>
       <div id="mob-home-map" class="mob-map-card">

--- a/web/js/views/home.js
+++ b/web/js/views/home.js
@@ -71,13 +71,8 @@ async function renderHomeMobile(container) {
   container.innerHTML = `
     <div>
       <div class="mob-hero">
+        <chlam-globe-bg variant="globe" tint="#163b2b"></chlam-globe-bg>
         <div class="mob-hero-inner">
-          <div class="mob-hero-eyebrow">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"
-              stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/>
-              <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-            MODEL ORGANISM DB
-          </div>
           <h1>ChlamAtlas</h1>
           <p>The authoritative research database for <em>Chlamydia</em> — genomics, mutant phenotypes, and structural biology across three model strains.</p>
         </div>
@@ -95,7 +90,7 @@ async function renderHomeMobile(container) {
           <path d="M16 2C16 5 8 7 8 10C8 13 16 15 16 18C16 21 8 22 8 22"/>
           <line x1="8" y1="2" x2="16" y2="2"/><line x1="8" y1="22" x2="16" y2="22"/></svg>
         <span class="t">Genomes</span>
-        <button class="more" id="mob-home-all-genomes">Browse →</button>
+        <span style="margin-left:auto;font-size:12px;color:var(--mob-ink-3);font-family:var(--mob-mono);">tap to browse</span>
       </div>
       <div id="mob-home-strain-cards"></div>
 
@@ -103,7 +98,7 @@ async function renderHomeMobile(container) {
         <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"
           style="color:var(--mob-green-ink)"><path d="M13 2L4.5 13H11L10 22L19.5 11H13L13 2Z"/></svg>
         <span class="t">Mutants</span>
-        <button class="more" id="mob-home-all-mutants">All →</button>
+        <span style="margin-left:auto;font-size:12px;color:var(--mob-ink-3);font-family:var(--mob-mono);">tap to browse</span>
       </div>
       <div id="mob-home-collection-rows"></div>
 
@@ -119,13 +114,6 @@ async function renderHomeMobile(container) {
 
       <div class="mob-pad-bottom"></div>
     </div>`;
-
-  container.querySelector('#mob-home-all-genomes').addEventListener('click', () => {
-    window.dispatchEvent(new CustomEvent('chlamatlas:navigate', { detail: { tab: 'genomes' } }));
-  });
-  container.querySelector('#mob-home-all-mutants').addEventListener('click', () => {
-    window.dispatchEvent(new CustomEvent('chlamatlas:navigate', { detail: { tab: 'mutants' } }));
-  });
 
   // Fetch data in parallel
   const [strainRes, mutRes, geneRes] = await Promise.all([
@@ -171,9 +159,11 @@ async function renderHomeMobile(container) {
           <div class="sbar" style="background:${color};"></div>
           <img class="sicon" src="${esc(icon)}" alt="${esc(s.common_name)}" onerror="this.style.display='none'">
           <div style="flex:1;min-width:0;">
-            <div class="scode" style="color:${color};">${esc(s.common_name)}</div>
-            <div class="sname"><em>${esc(species)}</em></div>
-            <div class="scount">${Number(gCount).toLocaleString()} genes</div>
+            <div style="font-style:italic;font-size:15px;color:var(--mob-ink);font-weight:500;margin-bottom:3px;"><em>${esc(species)}</em></div>
+            <div style="display:flex;align-items:center;gap:5px;">
+              <span class="scode" style="color:${color};font-size:13px;">${esc(s.common_name)}</span>
+              <span class="scount" style="margin-top:0;">· ${Number(gCount).toLocaleString()} genes</span>
+            </div>
           </div>
           ${chevron}
         </div>`;

--- a/web/js/views/home.js
+++ b/web/js/views/home.js
@@ -1,5 +1,8 @@
 // ChlamAtlas — Home tab
 import { sb, state } from '../client.js?v=82';
+import { isMobileViewport } from '../app.js?v=82';
+
+const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
 
 const ORGANISMS = [
   {
@@ -64,7 +67,172 @@ function countryLatLng(country) {
   return COUNTRY_CENTROIDS[country.toLowerCase().trim()] ?? null;
 }
 
+async function renderHomeMobile(container) {
+  container.innerHTML = `
+    <div>
+      <div class="mob-hero">
+        <div class="mob-hero-inner">
+          <div class="mob-hero-eyebrow">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"
+              stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/>
+              <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+            MODEL ORGANISM DB
+          </div>
+          <h1>ChlamAtlas</h1>
+          <p>The authoritative research database for <em>Chlamydia</em> — genomics, mutant phenotypes, and structural biology across three model strains.</p>
+        </div>
+      </div>
+
+      <div class="mob-hero-stats">
+        <div class="mob-hstat"><div class="n" id="mob-stat-genes">—</div><div class="l">Genes</div></div>
+        <div class="mob-hstat"><div class="n" id="mob-stat-mutants">—</div><div class="l">Mutants</div></div>
+        <div class="mob-hstat"><div class="n" id="mob-stat-strains">3</div><div class="l">Strains</div></div>
+      </div>
+
+      <div class="mob-home-sec-h">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"
+          style="color:var(--mob-green-ink)"><path d="M8 2C8 5 16 7 16 10C16 13 8 15 8 18C8 21 16 22 16 22"/>
+          <path d="M16 2C16 5 8 7 8 10C8 13 16 15 16 18C16 21 8 22 8 22"/>
+          <line x1="8" y1="2" x2="16" y2="2"/><line x1="8" y1="22" x2="16" y2="22"/></svg>
+        <span class="t">Genomes</span>
+        <button class="more" id="mob-home-all-genomes">Browse →</button>
+      </div>
+      <div id="mob-home-strain-cards"></div>
+
+      <div class="mob-home-sec-h">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"
+          style="color:var(--mob-green-ink)"><path d="M13 2L4.5 13H11L10 22L19.5 11H13L13 2Z"/></svg>
+        <span class="t">Mutants</span>
+        <button class="more" id="mob-home-all-mutants">All →</button>
+      </div>
+      <div id="mob-home-collection-rows"></div>
+
+      <div class="mob-home-sec-h">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"
+          style="color:var(--mob-green-ink)"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
+          <circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+        <span class="t">Community</span>
+      </div>
+      <div id="mob-home-map" class="mob-map-card">
+        <div id="mob-leaflet-map" style="width:100%;height:100%;"></div>
+      </div>
+
+      <div class="mob-pad-bottom"></div>
+    </div>`;
+
+  container.querySelector('#mob-home-all-genomes').addEventListener('click', () => {
+    window.dispatchEvent(new CustomEvent('chlamatlas:navigate', { detail: { tab: 'genomes' } }));
+  });
+  container.querySelector('#mob-home-all-mutants').addEventListener('click', () => {
+    window.dispatchEvent(new CustomEvent('chlamatlas:navigate', { detail: { tab: 'mutants' } }));
+  });
+
+  // Fetch data in parallel
+  const [strainRes, mutRes, geneRes] = await Promise.all([
+    sb.from('strains').select('common_name,genes(count)').eq('is_active', true),
+    sb.from('mutants').select('collection'),
+    sb.from('genes').select('id', { count: 'exact', head: true }),
+  ]);
+
+  const geneCount    = geneRes.count ?? 0;
+  const mutantCounts = {};
+  (mutRes.data ?? []).forEach(m => {
+    mutantCounts[m.collection] = (mutantCounts[m.collection] ?? 0) + 1;
+  });
+  const totalMutants = (mutRes.data ?? []).length;
+
+  const statGenesEl   = container.querySelector('#mob-stat-genes');
+  const statMutantsEl = container.querySelector('#mob-stat-mutants');
+  if (statGenesEl)   statGenesEl.textContent   = geneCount.toLocaleString();
+  if (statMutantsEl) statMutantsEl.textContent  = totalMutants.toLocaleString();
+
+  const strainColors  = { 'CT-L2': '#2f9e6e', 'CT-D': '#b14a93', 'CM': '#3f7fc4' };
+  const strainIcons   = {
+    'CT-L2': '/design/icons_transparent/L2icon_transparent.png',
+    'CT-D':  '/design/icons_transparent/CTDicon_transparent.png',
+    'CM':    '/design/icons_transparent/CMicon_transparent.png',
+  };
+  const strainSpecies = {
+    'CT-L2': 'C. trachomatis L2/434',
+    'CT-D':  'C. trachomatis D/UW-3',
+    'CM':    'C. muridarum Nigg',
+  };
+  const chevron = `<svg style="margin-left:auto;flex-shrink:0;color:#c8cec9" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><polyline points="9 18 15 12 9 6"/></svg>`;
+
+  const strainCards = container.querySelector('#mob-home-strain-cards');
+  if (strainCards && strainRes.data) {
+    strainCards.innerHTML = strainRes.data.map(s => {
+      const color   = strainColors[s.common_name] ?? '#2f9e6e';
+      const icon    = strainIcons[s.common_name]  ?? '';
+      const species = strainSpecies[s.common_name] ?? '';
+      const gCount  = s.genes?.[0]?.count ?? '—';
+      return `
+        <div class="mob-strain-card" data-strain="${esc(s.common_name)}">
+          <div class="sbar" style="background:${color};"></div>
+          <img class="sicon" src="${esc(icon)}" alt="${esc(s.common_name)}" onerror="this.style.display='none'">
+          <div style="flex:1;min-width:0;">
+            <div class="scode" style="color:${color};">${esc(s.common_name)}</div>
+            <div class="sname"><em>${esc(species)}</em></div>
+            <div class="scount">${Number(gCount).toLocaleString()} genes</div>
+          </div>
+          ${chevron}
+        </div>`;
+    }).join('');
+
+    strainCards.querySelectorAll('[data-strain]').forEach(card => {
+      card.addEventListener('click', () => {
+        window.__preferredStrain = card.dataset.strain;
+        window.dispatchEvent(new CustomEvent('chlamatlas:navigate', { detail: { tab: 'genomes' } }));
+      });
+    });
+  }
+
+  const COLLECTIONS_MOBILE = [
+    { id: 'CT_L2',    label: 'C. trachomatis', sub: 'CT-L2',   icon: '/design/icons_transparent/L2icon_transparent.png' },
+    { id: 'CM',       label: 'C. muridarum',   sub: 'CM',      icon: '/design/icons_transparent/CMicon_transparent.png' },
+    { id: 'Lucky17',  label: 'Lucky 17',        sub: 'Curated', icon: '/design/icons_transparent/L17icon_transparent.png' },
+    { id: 'Chimeras', label: 'Chimeras',        sub: 'L2 × CM', icon: '/design/icons_transparent/Chimeraicon_transparent.png' },
+  ];
+  const collRows = container.querySelector('#mob-home-collection-rows');
+  if (collRows) {
+    collRows.innerHTML = COLLECTIONS_MOBILE.map(c => {
+      const n = mutantCounts[c.id] ?? 0;
+      return `
+        <div class="mob-minirow" data-collection="${esc(c.id)}">
+          <img src="${esc(c.icon)}" alt="${esc(c.label)}" style="width:34px;height:34px;object-fit:contain;flex-shrink:0;" onerror="this.style.display='none'">
+          <div style="flex:1;min-width:0;">
+            <div class="mn">${esc(c.label)}</div>
+            <div class="ms">${esc(c.sub)} · ${n} mutants</div>
+          </div>
+          ${chevron}
+        </div>`;
+    }).join('');
+
+    collRows.querySelectorAll('[data-collection]').forEach(row => {
+      row.addEventListener('click', () => {
+        window.__mutantCollection = row.dataset.collection;
+        window.dispatchEvent(new CustomEvent('chlamatlas:navigate', { detail: { tab: 'mutants' } }));
+      });
+    });
+  }
+
+  // Community map
+  const mapEl = container.querySelector('#mob-leaflet-map');
+  if (mapEl && window.L) {
+    try {
+      const map = window.L.map(mapEl, { zoomControl: false, attributionControl: true })
+        .setView([30, 0], 1);
+      window.L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+        attribution: '© OpenStreetMap · © CARTO', maxZoom: 10,
+      }).addTo(map);
+    } catch (e) { /* map not critical */ }
+  }
+}
+
 export async function renderHome(container) {
+  if (isMobileViewport()) {
+    return renderHomeMobile(container);
+  }
   container.innerHTML = `
     <!-- ── Masthead ── -->
     <div class="home-masthead" style="background:#0f4530;overflow:hidden;position:relative;">
@@ -495,8 +663,8 @@ async function loadTopContributors(container) {
       return `
         <div style="display:flex;align-items:center;gap:8px;">
           <span style="font-size:13px;line-height:1;">${medals[i]}</span>
-          <span style="font-size:12px;font-weight:600;color:#111;flex:1;">${name}</span>
-          ${lab ? `<span style="font-size:11px;color:#9ca3af;">${lab}</span>` : ''}
+          <span style="font-size:12px;font-weight:600;color:#111;flex:1;">${esc(name)}</span>
+          ${lab ? `<span style="font-size:11px;color:#9ca3af;">${esc(lab)}</span>` : ''}
           <span style="font-size:11px;font-family:'DM Mono',monospace;color:#bbb;margin-left:8px;">${t.count}</span>
         </div>`;
     }).join('');
@@ -533,7 +701,7 @@ async function loadActivityFeed(container) {
     }
 
     const lines = data.map(u =>
-      `${u.title} <span style="color:#bbb">· ${relativeTime(u.created_at)}</span>`
+      `${esc(u.title)} <span style="color:#bbb">· ${relativeTime(u.created_at)}</span>`
     );
 
     let i = 0;

--- a/web/js/views/mutants.js
+++ b/web/js/views/mutants.js
@@ -377,7 +377,7 @@ function _mobRenderMutantRows(container, all, sort, filter, search) {
   });
 }
 
-async function _mobLoadMutantDetail(mutantUUID) {
+export async function _mobLoadMutantDetail(mutantUUID) {
   pushMobileDetail({
     title: '…',
     render: (scroll) => {

--- a/web/js/views/mutants.js
+++ b/web/js/views/mutants.js
@@ -1,5 +1,6 @@
 // ChlamAtlas — Mutants tab (full two-panel view)
 import { sb, state, toggleFavoriteDB } from '../client.js?v=82';
+import { isMobileViewport, pushMobileDetail, onMobScroll } from '../app.js?v=82';
 
 const COLLECTIONS = [
   { id: 'CT_L2',    label: 'C. trachomatis', icon: '/design/icons_transparent/L2icon_transparent.png' },
@@ -144,6 +145,622 @@ let _geneDataMap      = new Map();
 let _creatorOptions   = [];  // cached distinct creator_name values for current collection
 let _markerOptions    = [];  // cached distinct marker values for current collection
 
+// ─── Mobile mutant constants ──────────────────────────────
+const MOB_TYPE = {
+  deletion:      { color: '#C0392B', glyph: 'Δ',  glyphSize: 19 },
+  transposon:    { color: '#059669', glyph: '::',  glyphSize: 15 },
+  chimera:       { color: '#8466C4', glyph: '×',   glyphSize: 20 },
+  chemical:      { color: '#2563eb', glyph: '•',   glyphSize: 22 },
+  intron:        { color: '#ca8a04', glyph: '⟂',   glyphSize: 16 },
+  recombination: { color: '#8466C4', glyph: '×',   glyphSize: 20 },
+};
+const MOB_TYPE_DEFAULT = { color: '#8b958f', glyph: '?', glyphSize: 16 };
+
+const MOB_GRP_COLOR = {
+  CT_L2:    '#2f9e6e',
+  CM:       '#3f7fc4',
+  Lucky17:  '#C2912B',
+  Chimeras: '#8466C4',
+};
+
+function _renderMobileMutantList(container) {
+  container.style.padding = '0';
+  container.innerHTML = `
+    <div class="mob-lt-wrap" style="padding-top:8px;">
+      <div class="mob-lt-eyebrow">Mutants</div>
+      <h1 class="mob-lt-title">Mutants</h1>
+    </div>
+    <div class="mob-lt-sub" style="padding:0 20px 4px;" id="mob-mut-sub">Loading…</div>
+
+    <div class="mob-sticky-bar" id="mob-mut-toolbar">
+      <div class="mob-search-field">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#9aa39c" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <input id="mob-mut-search" type="search" autocomplete="off" placeholder="Search mutants, alleles, genes…" />
+        <button id="mob-mut-search-clear" style="display:none;background:none;border:none;color:var(--mob-ink-3);cursor:pointer;padding:0;font-size:14px;">✕</button>
+      </div>
+      <div class="mob-chip-row" style="padding:0;">
+        <div class="mob-seg" id="mob-mut-sort">
+          <button class="mob-seg-btn active" data-sort="collection">Collection</button>
+          <button class="mob-seg-btn" data-sort="az">A–Z</button>
+          <button class="mob-seg-btn" data-sort="type">Type</button>
+        </div>
+        <div style="width:.5px;background:var(--mob-line);margin:6px 0;flex-shrink:0;"></div>
+        <button class="mob-chip active" data-mf="all">All</button>
+        <button class="mob-chip" data-mf="published">Published</button>
+        <button class="mob-chip" data-mf="deletion">
+          <span class="mob-dot" style="background:#C0392B;"></span>Deletion
+        </button>
+        <button class="mob-chip" data-mf="transposon">
+          <span class="mob-dot" style="background:#059669;"></span>Transposon
+        </button>
+        <button class="mob-chip" data-mf="chimera">
+          <span class="mob-dot" style="background:#8466C4;"></span>Chimera
+        </button>
+      </div>
+    </div>
+
+    <div id="mob-mut-list" style="background:var(--mob-bg);"></div>
+    <div class="mob-pad-bottom"></div>`;
+
+  let mobMutSort   = 'collection';
+  let mobMutFilter = 'all';
+  let mobMutSearch = '';
+  let allMutants   = [];
+
+  onMobScroll(container, 60, 'Mutants');
+
+  _mobLoadMutantListData().then(data => {
+    allMutants = data;
+    const subEl = container.querySelector('#mob-mut-sub');
+    if (subEl) subEl.textContent = `${data.length.toLocaleString()} engineered strains across four collections`;
+    _mobRenderMutantRows(container, allMutants, mobMutSort, mobMutFilter, mobMutSearch);
+  });
+
+  const searchInput = container.querySelector('#mob-mut-search');
+  const searchClear = container.querySelector('#mob-mut-search-clear');
+  let searchTimer;
+  searchInput.addEventListener('input', () => {
+    mobMutSearch = searchInput.value.trim().toLowerCase();
+    searchClear.style.display = mobMutSearch ? '' : 'none';
+    clearTimeout(searchTimer);
+    searchTimer = setTimeout(() => _mobRenderMutantRows(container, allMutants, mobMutSort, mobMutFilter, mobMutSearch), 250);
+  });
+  searchClear.addEventListener('click', () => {
+    searchInput.value = ''; mobMutSearch = '';
+    searchClear.style.display = 'none';
+    _mobRenderMutantRows(container, allMutants, mobMutSort, mobMutFilter, mobMutSearch);
+  });
+
+  container.querySelectorAll('#mob-mut-sort .mob-seg-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      container.querySelectorAll('#mob-mut-sort .mob-seg-btn').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      mobMutSort = btn.dataset.sort;
+      _mobRenderMutantRows(container, allMutants, mobMutSort, mobMutFilter, mobMutSearch);
+    });
+  });
+
+  container.querySelectorAll('.mob-chip[data-mf]').forEach(chip => {
+    chip.addEventListener('click', () => {
+      container.querySelectorAll('.mob-chip[data-mf]').forEach(c => c.classList.remove('active'));
+      chip.classList.add('active');
+      mobMutFilter = chip.dataset.mf;
+      _mobRenderMutantRows(container, allMutants, mobMutSort, mobMutFilter, mobMutSearch);
+    });
+  });
+}
+
+async function _mobLoadMutantListData() {
+  try {
+    const { data } = await sb
+      .from('mutants')
+      .select('id,mutant_id,name,mutation_type,collection,is_published,target_gene_ids')
+      .order('mutant_id');
+    return data ?? [];
+  } catch (err) {
+    console.error('[ChlamAtlas] _mobLoadMutantListData:', err);
+    return [];
+  }
+}
+
+function _mobRenderMutantRows(container, all, sort, filter, search) {
+  const list = container.querySelector('#mob-mut-list');
+  if (!list) return;
+  const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+
+  let rows = all;
+  if (filter === 'published') rows = rows.filter(m => m.is_published);
+  if (['deletion','transposon','chimera','chemical','intron'].includes(filter)) {
+    rows = rows.filter(m => m.mutation_type === filter);
+  }
+  if (search) {
+    rows = rows.filter(m =>
+      (m.name ?? '').toLowerCase().includes(search) ||
+      (m.mutant_id ?? '').toLowerCase().includes(search) ||
+      (m.mutation_type ?? '').toLowerCase().includes(search)
+    );
+  }
+
+  if (!rows.length) {
+    list.innerHTML = '<div style="padding:28px 20px;text-align:center;color:var(--mob-ink-3);font-size:14px;">No mutants found.</div>';
+    return;
+  }
+
+  const COLL_ORDER  = ['CT_L2', 'CM', 'Lucky17', 'Chimeras'];
+  const COLL_LABELS = { CT_L2: 'CT-L2', CM: 'CM', Lucky17: 'Lucky 17', Chimeras: 'Chimeras' };
+  const COLL_ICONS  = {
+    CT_L2:    '/design/icons_transparent/L2icon_transparent.png',
+    CM:       '/design/icons_transparent/CMicon_transparent.png',
+    Lucky17:  '/design/icons_transparent/L17icon_transparent.png',
+    Chimeras: '/design/icons_transparent/Chimeraicon_transparent.png',
+  };
+  const TYPE_ORDER = ['deletion','transposon','chemical','chimera','intron','recombination'];
+
+  let groups;
+  if (sort === 'az') {
+    groups = [{ key: 'All mutants', icon: null, color: null, rows: [...rows].sort((a,b) => (a.name||a.mutant_id||'').localeCompare(b.name||b.mutant_id||'')) }];
+  } else if (sort === 'type') {
+    const g = new Map();
+    TYPE_ORDER.forEach(t => g.set(t, []));
+    rows.forEach(m => { const t = m.mutation_type ?? 'other'; if (!g.has(t)) g.set(t, []); g.get(t).push(m); });
+    groups = [...g.entries()].filter(([,v]) => v.length).map(([k,v]) => ({
+      key: k.charAt(0).toUpperCase() + k.slice(1),
+      icon: null,
+      color: (MOB_TYPE[k] ?? MOB_TYPE_DEFAULT).color,
+      rows: v,
+    }));
+  } else {
+    const g = new Map(COLL_ORDER.map(c => [c, []]));
+    rows.forEach(m => { const c = m.collection ?? 'CT_L2'; if (!g.has(c)) g.set(c, []); g.get(c).push(m); });
+    groups = COLL_ORDER.filter(c => g.get(c)?.length).map(c => ({
+      key: COLL_LABELS[c] ?? c,
+      icon: COLL_ICONS[c] ?? null,
+      color: MOB_GRP_COLOR[c] ?? null,
+      rows: g.get(c),
+    }));
+  }
+
+  const toolbarEl = container.querySelector('#mob-mut-toolbar');
+  const navH      = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--mob-nav-h')) || 52;
+  const stickyTop = toolbarEl ? toolbarEl.getBoundingClientRect().height + navH : navH + 116;
+  const chevron   = `<svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><polyline points="9 18 15 12 9 6"/></svg>`;
+
+  list.innerHTML = groups.map(grp => {
+    const iconEl = grp.icon
+      ? `<img src="${esc(grp.icon)}" alt="" style="width:18px;height:18px;object-fit:contain;flex-shrink:0;" onerror="this.style.display='none'">`
+      : grp.color ? `<span style="width:10px;height:10px;border-radius:3px;background:${grp.color};flex-shrink:0;display:inline-block;"></span>` : '';
+
+    const rowsHTML = grp.rows.map((m, i) => {
+      const mt      = MOB_TYPE[m.mutation_type] ?? MOB_TYPE_DEFAULT;
+      const isFav   = state.favorites.mutants.has(String(m.id));
+      const display = m.name || m.mutant_id;
+      const typeLbl = TYPE_LABELS[m.mutation_type] ?? m.mutation_type ?? '';
+      const hasSep  = i < grp.rows.length - 1;
+
+      return `
+        <div class="mob-grow" data-mut-id="${m.id}">
+          <div class="mob-bar" style="background:${mt.color};"></div>
+          <div class="mob-mut-tile" style="background:${mt.color}16;box-shadow:inset 0 0 0 1px ${mt.color}33;font-size:${mt.glyphSize}px;color:${mt.color};">${mt.glyph}</div>
+          <div class="mob-meta">
+            <div class="mob-gname" style="font-family:var(--mob-mono);font-weight:600;">${esc(display)}<span class="mob-loc" style="color:${mt.color};font-family:var(--mob-sans);font-size:12px;margin-left:6px;">${esc(typeLbl)}</span></div>
+            <div class="mob-gfunc">${m.mutant_id !== display ? esc(m.mutant_id) + ' · ' : ''}${esc(m.collection ?? '')}</div>
+          </div>
+          ${state.user ? `<button class="mob-star${isFav?' on':''}" data-fav-mid="${m.id}" aria-label="Save">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="${isFav?'#e8b400':'none'}" stroke="${isFav?'#e8b400':'currentColor'}" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+          </button>` : ''}
+          <span class="mob-chev">${chevron}</span>
+          ${hasSep ? '<div class="mob-sep"></div>' : ''}
+        </div>`;
+    }).join('');
+
+    return `
+      <div class="mob-section-h" style="top:${stickyTop}px;">
+        ${iconEl}<span>${esc(grp.key)}</span>
+        <span class="mob-sh-count">· ${grp.rows.length}</span>
+      </div>
+      <div style="background:var(--mob-paper);">${rowsHTML}</div>`;
+  }).join('');
+
+  list.querySelectorAll('.mob-grow[data-mut-id]').forEach(row => {
+    row.addEventListener('click', () => _mobLoadMutantDetail(row.dataset.mutId));
+  });
+
+  list.querySelectorAll('.mob-star[data-fav-mid]').forEach(btn => {
+    btn.addEventListener('click', async e => {
+      e.stopPropagation();
+      if (!state.user) { window.__showAuthModal?.('signin'); return; }
+      const nowFav = await toggleFavoriteDB('mutant', btn.dataset.favMid);
+      btn.classList.toggle('on', nowFav);
+      const svg = btn.querySelector('svg');
+      if (svg) { svg.setAttribute('fill', nowFav ? '#e8b400' : 'none'); svg.setAttribute('stroke', nowFav ? '#e8b400' : 'currentColor'); }
+    });
+  });
+}
+
+async function _mobLoadMutantDetail(mutantUUID) {
+  pushMobileDetail({
+    title: '…',
+    render: (scroll) => {
+      scroll.innerHTML = '<div style="padding:40px 20px;text-align:center;color:var(--mob-ink-3);font-size:14px;">Loading…</div>';
+    },
+  });
+
+  const [mutantRes, pipeRes, phenoRes] = await Promise.all([
+    sb.from('mutants')
+      .select(`id,mutant_id,name,mutation_type,mutation_method,plasmid_used,marker,
+               creator,creator_name,contributed_by,background_strain_id,
+               is_published,notes,target_gene_ids,availability,
+               recombination_start,recombination_end,ortholog_span_cm,collection,
+               strains!background_strain_id(common_name,species)`)
+      .eq('id', mutantUUID)
+      .single(),
+    sb.from('mutant_pipeline')
+      .select('*')
+      .eq('mutant_id', mutantUUID)
+      .maybeSingle(),
+    sb.from('mutant_phenotypes')
+      .select('*')
+      .eq('mutant_id', mutantUUID),
+  ]);
+
+  const m = mutantRes.data;
+  if (!m) return;
+
+  let genes = [];
+  if (m.target_gene_ids?.length) {
+    const { data } = await sb
+      .from('genes')
+      .select('id,locus_tag,gene_name,functional_category,proteins(alphafold_results(thumbnail_path))')
+      .in('id', m.target_gene_ids);
+    genes = (data ?? []).sort((a, b) => (a.locus_tag ?? '').localeCompare(b.locus_tag ?? ''));
+  }
+
+  const title = m.name || m.mutant_id;
+  const scroll = document.getElementById('mob-detail-scroll');
+  if (scroll) {
+    scroll.innerHTML = '';
+    _renderMutantDetailMobileHTML(m, genes, phenoRes.data ?? [], pipeRes.data ?? null, scroll);
+  }
+  const titleEl = document.getElementById('mob-bar-title');
+  if (titleEl) titleEl.textContent = title;
+}
+
+function _renderMutantDetailMobileHTML(m, genes, phenos, pipe, scroll) {
+  const isChimera   = m.mutation_type === 'chimera';
+  const isLabMember = state.userRole === 'lab_member' || state.userRole === 'admin';
+  const mt          = MOB_TYPE[m.mutation_type] ?? MOB_TYPE_DEFAULT;
+  const collColor   = MOB_GRP_COLOR[m.collection] ?? '#8b958f';
+  const collIcon    = {
+    CT_L2:    '/design/icons_transparent/L2icon_transparent.png',
+    CM:       '/design/icons_transparent/CMicon_transparent.png',
+    Lucky17:  '/design/icons_transparent/L17icon_transparent.png',
+    Chimeras: '/design/icons_transparent/Chimeraicon_transparent.png',
+  }[m.collection] ?? '';
+  const isFav       = state.favorites.mutants.has(String(m.id));
+  const displayName = m.name || m.mutant_id;
+  const locSub      = `${m.collection ?? ''} · ${m.mutant_id}`;
+  const typeLabel   = TYPE_LABELS[m.mutation_type] ?? m.mutation_type ?? '';
+  const pubColor    = m.is_published ? '#1c8c7e' : '#d98a2b';
+  const pubLabel    = m.is_published ? 'Published' : 'Unpublished';
+  const availMap    = {
+    'Available':   { color: '#1c8c7e', bg: '#e6f3ef' },
+    'On request':  { color: '#c2912b', bg: '#f6efdd' },
+    'Restricted':  { color: '#c0392b', bg: '#f6e6e4' },
+  };
+  const avail  = availMap[m.availability] ?? { color: '#8b958f', bg: '#f4f4f4' };
+  const pheno  = phenos[0];
+  const esc    = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+
+  scroll.innerHTML = `
+    <div style="background:${collColor}12;border-bottom:3px solid ${collColor};padding-bottom:12px;">
+      <div class="mob-d-head">
+        <img src="${esc(collIcon)}" alt="" style="width:52px;height:52px;object-fit:contain;flex-shrink:0;" onerror="this.style.display='none'">
+        <div class="mob-d-title-block">
+          <div class="mob-d-title" style="font-family:var(--mob-mono);font-size:25px;">${esc(displayName)}</div>
+          <span class="mob-d-loc">${esc(locSub)}</span>
+        </div>
+        <div class="mob-d-actions">
+          <button class="mob-gbtn mob-fav-btn${isFav?' saved-on':''}" data-id="${m.id}" aria-label="Save mutant">
+            <svg width="19" height="19" viewBox="0 0 24 24" fill="${isFav?'#e8b400':'none'}" stroke="${isFav?'#e8b400':'currentColor'}" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+          </button>
+        </div>
+      </div>
+      <div class="mob-tags-row" style="padding:0 20px;">
+        <span class="mob-tag" style="color:${mt.color};border-color:${mt.color};background:${mt.color}14;">${esc(typeLabel)}</span>
+        <span class="mob-tag" style="color:${pubColor};border-color:${pubColor};background:${pubColor}14;">${esc(pubLabel)}</span>
+        <span class="mob-tag" style="color:${collColor};border-color:${collColor};background:${collColor}14;">${esc(m.collection ?? '')}</span>
+      </div>
+      <div class="mob-meta-row" style="padding:8px 20px 0;">
+        <span style="font-size:12px;font-style:italic;color:var(--mob-ink-3);">${m.is_published ? 'Published' : 'Unpublished'}</span>
+      </div>
+    </div>
+
+    <div class="mob-card" id="mob-mut-targets-card">
+      <div class="mob-card-h">${isChimera ? 'Recombined Region' : 'Targeted Genes'}</div>
+      ${isChimera
+        ? `<div id="mob-chimera-placeholder" style="padding:10px 0;color:var(--mob-ink-3);font-size:13px;text-align:center;">Loading recombination data…</div>`
+        : _mobTargetedGenesHTML(genes, m.mutation_type)}
+    </div>
+
+    ${isChimera ? `<div class="mob-card" id="mob-gene-exchange-card">
+      <div class="mob-card-h">Gene Exchange</div>
+      <div id="mob-exchange-placeholder" style="padding:10px 0;color:var(--mob-ink-3);font-size:13px;text-align:center;">Loading…</div>
+    </div>` : ''}
+
+    <div class="mob-card">
+      <div class="mob-card-h">Mutation</div>
+      <div class="mob-kv-grid">
+        <div class="mob-kv"><div class="mob-k">Type</div><div class="mob-v sm">${esc(typeLabel)}</div></div>
+        <div class="mob-kv"><div class="mob-k">Allele</div><div class="mob-v sm" style="font-family:var(--mob-mono);">${esc(m.mutant_id ?? '—')}</div></div>
+      </div>
+      ${m.name ? `<div class="mob-genotype">${esc(m.name)}</div>` : ''}
+    </div>
+
+    <div class="mob-card">
+      <div class="mob-card-h">Construction</div>
+      <div class="mob-kv-grid">
+        <div class="mob-kv"><div class="mob-k">Method</div><div class="mob-v sm">${esc(m.mutation_method ?? '—')}</div></div>
+        <div class="mob-kv"><div class="mob-k">Background</div><div class="mob-v sm">${esc(m.strains?.common_name ?? '—')}</div></div>
+        <div class="mob-kv"><div class="mob-k">Marker</div><div class="mob-v sm" style="font-family:var(--mob-mono);">${esc(m.marker ?? '—')}</div></div>
+        <div class="mob-kv"><div class="mob-k">Collection</div><div class="mob-v sm">${esc(m.collection ?? '—')}</div></div>
+      </div>
+    </div>
+
+    <div class="mob-card">
+      <div class="mob-card-h">Phenotype</div>
+      <div style="margin-top:10px;font-size:14.5px;line-height:1.55;color:var(--mob-ink);">
+        ${pheno?.description
+          ? `<p style="margin:0;">${esc(pheno.description)}</p>`
+          : `<p style="margin:0;font-style:italic;color:var(--mob-ink-3);">No phenotype data yet.</p>`}
+      </div>
+    </div>
+
+    <div class="mob-card">
+      <div class="mob-card-h">Source</div>
+      <div class="mob-kv-grid">
+        <div class="mob-kv"><div class="mob-k">Lab</div><div class="mob-v sm">${esc(m.creator_name ?? '—')}</div></div>
+        <div class="mob-kv"><div class="mob-k">Status</div><div class="mob-v sm" style="color:${pubColor};">${esc(pubLabel)}</div></div>
+      </div>
+    </div>
+
+    <div class="mob-card">
+      <div class="mob-card-h">Availability</div>
+      <div style="margin-top:10px;">
+        <span class="mob-avail-pill" style="color:${avail.color};background:${avail.bg};">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><polyline points="12 8 12 12 14 14"/></svg>
+          ${esc(m.availability ?? 'Unknown')}
+        </span>
+      </div>
+    </div>
+
+    ${isLabMember && m.notes ? `
+    <div class="mob-card">
+      <div class="mob-card-h">Notes</div>
+      <div style="margin-top:10px;font-size:14px;line-height:1.55;color:var(--mob-ink);">${esc(m.notes)}</div>
+    </div>` : ''}
+
+    <div class="mob-pad-bottom"></div>`;
+
+  scroll.querySelector('.mob-fav-btn')?.addEventListener('click', async e => {
+    e.stopPropagation();
+    const btn = e.currentTarget;
+    const nowFav = await toggleFavoriteDB('mutant', m.id);
+    btn.classList.toggle('saved-on', nowFav);
+    const svg = btn.querySelector('svg');
+    if (svg) { svg.setAttribute('fill', nowFav ? '#e8b400' : 'none'); svg.setAttribute('stroke', nowFav ? '#e8b400' : 'currentColor'); }
+  });
+
+  scroll.querySelectorAll('[data-tg-gene]').forEach(row => {
+    row.addEventListener('click', () => {
+      window.__openGeneId = row.dataset.tgGene;
+      window.dispatchEvent(new CustomEvent('chlamatlas:navigate', { detail: { tab: 'genomes' } }));
+    });
+  });
+
+  const tgScroll = scroll.querySelector('#mob-tg-scroll');
+  const tgFade   = scroll.querySelector('#mob-tg-fade');
+  if (tgScroll && tgFade) {
+    const updateFade = () => {
+      tgFade.style.opacity = (tgScroll.scrollTop + tgScroll.clientHeight >= tgScroll.scrollHeight - 4) ? '0' : '1';
+    };
+    tgScroll.addEventListener('scroll', updateFade, { passive: true });
+    updateFade();
+  }
+
+  if (isChimera && m.recombination_start && m.recombination_end) {
+    _mobInjectChimeraSections(m, scroll);
+  }
+}
+
+function _mobTargetedGenesHTML(genes, mutationType) {
+  const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  if (!genes.length) return '<div style="margin-top:10px;font-style:italic;color:var(--mob-ink-3);font-size:14px;">No target genes recorded.</div>';
+
+  const ROLE = {
+    deletion:      { color: '#c0392b', bg: '#fce8e8', label: 'Deleted' },
+    transposon:    { color: '#059669', bg: '#e6f4f0', label: 'Insertion' },
+    chimera:       { color: '#8466c4', bg: '#f0ecfb', label: 'Swapped in' },
+    chemical:      { color: '#2563eb', bg: '#e8eefb', label: 'Point' },
+    intron:        { color: '#ca8a04', bg: '#fdf3e0', label: 'Intron' },
+    recombination: { color: '#8466c4', bg: '#f0ecfb', label: 'Recombined' },
+  };
+  const role = ROLE[mutationType] ?? { color: '#8b958f', bg: '#f4f4f4', label: 'Modified' };
+
+  const rowsHTML = genes.map((g, i) => {
+    const color   = CATEGORY_COLORS[g.functional_category] ?? CATEGORY_COLOR_DEFAULT;
+    const thumb   = g.proteins?.alphafold_results?.find(r => r.thumbnail_path)?.thumbnail_path;
+    const display = g.gene_name || g.locus_tag;
+    const hasSep  = i < genes.length - 1;
+    return `
+      <div class="mob-tg-row" data-tg-gene="${g.id}">
+        <div class="mob-tg-bar" style="background:${color};"></div>
+        <div class="mob-stile" style="width:30px;height:30px;border-radius:7px;flex-shrink:0;">
+          ${thumb ? `<img src="${esc(thumb)}" alt="" style="width:100%;height:100%;object-fit:cover;">` : `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="${color}" stroke-width="1.5" opacity="0.5"><circle cx="12" cy="12" r="8"/><circle cx="12" cy="12" r="4"/></svg>`}
+        </div>
+        <div class="mob-tg-meta">
+          <div class="mob-tg-name">${esc(display)}<span class="loc">${g.gene_name ? esc(g.locus_tag) : ''}</span></div>
+          <div class="mob-tg-func">${esc(g.functional_category ?? '')}</div>
+        </div>
+        <span class="mob-role-badge" style="color:${role.color};background:${role.bg};">${esc(role.label)}</span>
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#c8cec9" stroke-width="2.2" stroke-linecap="round"><polyline points="9 18 15 12 9 6"/></svg>
+        ${hasSep ? '<div style="position:absolute;left:0;right:0;bottom:0;height:.5px;background:var(--mob-line);"></div>' : ''}
+      </div>`;
+  }).join('');
+
+  const needsScroll = genes.length > 4;
+  return `
+    <div class="mob-tg-win">
+      <div class="mob-tg-scroll" id="mob-tg-scroll" style="max-height:${needsScroll ? '250px' : 'none'};overflow-y:${needsScroll ? 'auto' : 'visible'};">
+        ${rowsHTML}
+      </div>
+      ${needsScroll ? `
+        <div class="mob-tg-fade" id="mob-tg-fade"></div>
+        <div class="mob-tg-count-hint">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><polyline points="19 12 12 19 5 12"/></svg>
+          ${genes.length} loci · scroll to see all
+        </div>` : ''}
+    </div>`;
+}
+
+async function _mobInjectChimeraSections(m, scroll) {
+  const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  const start = m.recombination_start;
+  const end   = m.recombination_end;
+  const backboneStrain = m.strains?.common_name ?? 'CT-L2';
+  const isL2Backbone   = backboneStrain === 'CT-L2';
+  const GENOME_LEN     = isL2Backbone ? 1_044_459 : 1_072_949;
+  const BACKBONE_COLOR = isL2Backbone ? '#2f9e6e' : '#3f7fc4';
+  const RECOMB_COLOR   = isL2Backbone ? '#3f7fc4' : '#2f9e6e';
+  const BACKBONE_LABEL = isL2Backbone ? 'CT-L2' : 'CM';
+  const RECOMB_LABEL   = isL2Backbone ? 'CM' : 'CT-L2';
+
+  try {
+    const [startRes, endRes] = await Promise.all([
+      sb.from('genes').select('start_bp,end_bp,sort_index').eq('locus_tag', start).eq('strain_id', m.background_strain_id).maybeSingle(),
+      sb.from('genes').select('start_bp,end_bp,sort_index').eq('locus_tag', end  ).eq('strain_id', m.background_strain_id).maybeSingle(),
+    ]);
+
+    const sg = startRes.data; const eg = endRes.data;
+    const placeholder = scroll.querySelector('#mob-chimera-placeholder');
+
+    if (sg && eg && placeholder) {
+      const startBp = sg.start_bp ?? 0;
+      const endBp   = eg.end_bp   ?? sg.end_bp ?? 0;
+      const sizeKb  = Math.round(Math.abs(endBp - startBp) / 1000);
+      const pct     = ((Math.abs(endBp - startBp) / GENOME_LEN) * 100).toFixed(1);
+      const x0pct   = ((startBp / GENOME_LEN) * 100).toFixed(2);
+      const wpct    = ((Math.abs(endBp - startBp) / GENOME_LEN) * 100).toFixed(2);
+
+      const LANDMARKS = ['ompA', 'incA', 'gyrA', 'rpoB', 'secY'];
+      const lmOr = LANDMARKS.map(n => `gene_name.eq.${n},gene_symbol.eq.${n}`).join(',');
+      const { data: lmData } = await sb
+        .from('genes').select('gene_name,gene_symbol,start_bp')
+        .eq('strain_id', m.background_strain_id).or(lmOr);
+      const landmarks = (lmData ?? [])
+        .filter(g => g.start_bp != null)
+        .map(g => ({ name: (g.gene_symbol || g.gene_name || '').replace(/\s+[A-Z]{2,4}L?\d{4,}$/i,'').trim() || (g.gene_symbol || g.gene_name || ''), bp: g.start_bp }))
+        .filter((lm,i,arr) => arr.findIndex(x => x.name === lm.name) === i)
+        .sort((a,b) => a.bp - b.bp);
+
+      const rulerLandmarks = landmarks.map(lm => `
+        <div class="mob-rr-lm" style="left:${((lm.bp/GENOME_LEN)*100).toFixed(2)}%">
+          <div class="nm">${esc(lm.name)}</div><div class="tick"></div>
+        </div>`).join('');
+
+      placeholder.outerHTML = `
+        <div class="mob-rr-ruler"><div class="base"></div>${rulerLandmarks}</div>
+        <div class="mob-rr-barwrap">
+          <div class="mob-rr-kb">${sizeKb.toLocaleString()} kb</div>
+          <div class="mob-rr-bar">
+            <div class="mob-rr-block" style="left:${x0pct}%;width:${wpct}%;background:${RECOMB_COLOR};"></div>
+          </div>
+        </div>
+        <div class="mob-rr-span">${esc(start)}–${esc(end)}</div>
+        <div class="mob-rr-legend">
+          <div class="mob-rr-leg"><div class="sw" style="background:${BACKBONE_COLOR};"></div>${esc(BACKBONE_LABEL)} backbone</div>
+          <div class="mob-rr-leg"><div class="sw" style="background:${RECOMB_COLOR};"></div>${esc(RECOMB_LABEL)} recombined</div>
+          <div class="mob-rr-leg" style="font-weight:600;color:var(--mob-ink-3);">${sizeKb.toLocaleString()} kb · ${pct}% of genome</div>
+        </div>`;
+    }
+
+    const otherStrain = backboneStrain === 'CT-L2' ? 'CM' : 'CT-L2';
+    const { data: strainRows } = await sb.from('strains').select('id,common_name').in('common_name', [backboneStrain, otherStrain]);
+    const strainById = Object.fromEntries((strainRows ?? []).map(s => [s.common_name, s.id]));
+    const backboneId = strainById[backboneStrain];
+    const otherId    = strainById[otherStrain];
+    const exPlaceholder = scroll.querySelector('#mob-exchange-placeholder');
+    if (!backboneId || !otherId || !exPlaceholder) return;
+
+    const [siRes, eiRes] = await Promise.all([
+      sb.from('genes').select('sort_index').eq('locus_tag', start).eq('strain_id', backboneId).maybeSingle(),
+      sb.from('genes').select('sort_index').eq('locus_tag', end  ).eq('strain_id', backboneId).maybeSingle(),
+    ]);
+    const si = siRes.data?.sort_index; const ei = eiRes.data?.sort_index;
+    if (si == null || ei == null) { exPlaceholder.textContent = 'Gene exchange data unavailable'; return; }
+
+    const gf = 'id,locus_tag,gene_name,product,functional_category';
+    const { data: backboneGenes } = await sb.from('genes').select(gf)
+      .eq('strain_id', backboneId).gte('sort_index', Math.min(si,ei)).lte('sort_index', Math.max(si,ei)).order('sort_index');
+    if (!backboneGenes?.length) { exPlaceholder.textContent = 'No genes in range'; return; }
+
+    const backboneIds = backboneGenes.map(g => g.id);
+    const [orthA, orthB] = await Promise.all([
+      sb.from('orthologs').select('gene_id_a,genes!gene_id_b(id,locus_tag,gene_name,product,functional_category)').in('gene_id_a', backboneIds).eq('strain_id_b', otherId),
+      sb.from('orthologs').select('gene_id_b,genes!gene_id_a(id,locus_tag,gene_name,product,functional_category)').in('gene_id_b', backboneIds).eq('strain_id_a', otherId),
+    ]);
+    const orthologMap = new Map();
+    for (const o of (orthA.data ?? [])) if (o.genes) orthologMap.set(String(o.gene_id_a), o.genes);
+    for (const o of (orthB.data ?? [])) if (o.genes) orthologMap.set(String(o.gene_id_b), o.genes);
+
+    const withOrth    = backboneGenes.filter(g => orthologMap.has(String(g.id))).length;
+    const withoutOrth = backboneGenes.length - withOrth;
+    const swapIcon = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#b9c2bc" stroke-width="2" stroke-linecap="round"><path d="M7 16V4m0 0L3 8m4-4l4 4"/><path d="M17 8v12m0 0l4-4m-4 4l-4-4"/></svg>`;
+
+    const colHead = `
+      <div class="mob-gx-colhead">
+        <div class="h" style="color:var(--mob-s-l2);"><b>${esc(isL2Backbone ? 'CT-L2' : 'CM')}</b><span style="color:var(--mob-ink-3);">backbone</span></div>
+        <div style="flex:0 0 auto;color:var(--mob-ink-3);font-size:9px;">⇄</div>
+        <div class="h" style="color:var(--mob-s-cm);justify-content:flex-end;"><span style="color:var(--mob-ink-3);">recombined</span><b>${esc(isL2Backbone ? 'CM' : 'CT-L2')}</b></div>
+      </div>`;
+
+    const gxRows = backboneGenes.map(g => {
+      const ortho  = orthologMap.get(String(g.id));
+      const color  = CATEGORY_COLORS[g.functional_category] ?? CATEGORY_COLOR_DEFAULT;
+      const noOrth = !ortho;
+      return `
+        <div class="mob-gx-row${noOrth?' noortho':''}">
+          <div class="mob-gx-bar" style="background:${noOrth?'#d99a3e':color};"></div>
+          <div class="mob-gx-main">
+            <div class="mob-gx-pair">
+              <div class="mob-gx-side"><span class="mob-gx-loc">${esc(g.locus_tag)}</span>${g.gene_name?`<span class="mob-gx-sym">${esc(g.gene_name)}</span>`:''}</div>
+              <div class="mob-gx-arrow">${swapIcon}</div>
+              <div class="mob-gx-side r">${noOrth?`<span class="mob-gx-none">no CM ortholog</span>`:`<span class="mob-gx-loc">${esc(ortho.locus_tag)}</span>${ortho.gene_name?`<span class="mob-gx-sym">${esc(ortho.gene_name)}</span>`:''}`}</div>
+            </div>
+            <div class="mob-gx-prod">${esc(g.product ?? '')}</div>
+          </div>
+        </div>`;
+    }).join('');
+
+    const needsScroll = backboneGenes.length > 4;
+    exPlaceholder.outerHTML = `
+      <div style="margin-top:8px;font-size:12px;color:var(--mob-ink-3);">
+        ${backboneGenes.length} genes · <span style="color:var(--mob-green-ink);">${withOrth} with ${esc(otherStrain)} orthologs</span>
+        ${withoutOrth ? ` · <span style="color:#c2702b;">${withoutOrth} without ortholog</span>` : ''}
+      </div>
+      <div class="mob-tg-win" style="margin-top:10px;">
+        ${colHead}
+        <div style="max-height:${needsScroll?'250px':'none'};overflow-y:${needsScroll?'auto':'visible'};">
+          ${gxRows}
+        </div>
+      </div>`;
+
+  } catch (err) {
+    console.error('[ChlamAtlas] _mobInjectChimeraSections:', err);
+    const ph = scroll.querySelector('#mob-chimera-placeholder') ?? scroll.querySelector('#mob-exchange-placeholder');
+    if (ph) ph.textContent = 'Error loading chimera data.';
+  }
+}
+
 // ─── Entry point ──────────────────────────────────────────
 
 export function renderMutants(container) {
@@ -160,6 +777,11 @@ export function renderMutants(container) {
   _moreOpen = false;
   _expandedSections = { type: false, strain: false, function: false, published: false, creator: false, marker: false };
   _geneDataMap = new Map();
+
+  if (isMobileViewport()) {
+    _renderMobileMutantList(container);
+    return;
+  }
 
   // Pre-select a mutant navigated to from another tab (e.g. gene detail Mutants panel)
   if (window.__openMutantId) {


### PR DESCRIPTION
## Summary

- Full mobile gene detail redesign — sections over cards, all 9 panels (Gene Info, Orthologs, Genomic Context, Protein, Cell Localization, Transcriptomics, Proteomics, Structure, Mutants), gradient header, edit sheet, footer
- Mobile gene list filter bar rebuilt to match desktop — sort dropdown (Locus / Gene name / Genomic order), active chip row, collapsible More panel (Characterization, Function, Structure, Expression, Mutants sections)
- Shell polish — Lucide SVG icons, reduced tab bar height, Tools submenu as bottom sheet, X buttons on Saved/Account sheets, nav always visible
- Gene map — consistent DM Sans font, drop-shadow follows clip-path arrow outline
- Mutants section in filter bar — strain-specific chips (L2: Tn/Deletion/Lucky 17/Chimera; CM: Tn/Deletion/Chimera; CT-D: hidden)
- Various bug fixes: CTL0001 default load, infinite scroll, star toggle, genomic order flat sort, EB/RB chips same row

## Test plan

- [ ] Gene list loads at CTL0001 on mobile for CT-L2
- [ ] Sort dropdown works (Locus tag / Gene name / Genomic order — no letter grouping for genomic order)
- [ ] More panel opens, all sections expand/collapse, chips filter correctly
- [ ] Mutants section shows correct chips per strain (L2 / CM / CT-D)
- [ ] Gene detail opens with all 9 sections populated
- [ ] Star toggle, back gesture, edit sheet work
- [ ] Desktop Genomes and Mutants panels unaffected (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)