### PR TITLE
fix(mobile): pipeline optimization — green title, ID stacking, SVG flame, no cards

### DIFF
--- a/web/css/pipeline.css
+++ b/web/css/pipeline.css
@@ -108,6 +108,45 @@
   text-align: center; border-top: 1px solid #f3f4f6;
 }
 
+/* ── Mobile overrides ─────────────────────────────────── */
+@media (max-width: 639px) {
+  /* Green title */
+  .pl-pipeline-title { color: #163b2b; }
+
+  /* Remove card chrome from group row containers */
+  .pl-group-card {
+    background: transparent !important;
+    border: none !important;
+    border-radius: 0 !important;
+    overflow: visible !important;
+    box-shadow: none !important;
+    border-top: 1px solid #e9ece9 !important;
+  }
+
+  /* Remove card chrome from stage key */
+  .pl-stage-key-card {
+    background: transparent !important;
+    border: none !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    padding: 0 0 8px !important;
+    margin-bottom: 8px !important;
+  }
+
+  /* Hide the verbose stage sequence text on mobile */
+  .pl-stage-key-seq { display: none; }
+
+  /* Larger tap targets for flame + star */
+  .pl-icon-btn { width: 32px; height: 32px; }
+
+  /* Picker popup: keep within viewport by anchoring right on mobile */
+  .pl-picker-popup {
+    left: auto;
+    right: 0;
+    transform: none;
+  }
+}
+
 /* Stage key legend pills */
 .skp-done    { background: #bbf7d0; }
 .skp-uw      { background: #ede9fe; border: 1px solid #c4b5fd; }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1,9 +1,9 @@
 // ChlamAtlas — main application entry point
-import { sb, state, SUPABASE_URL, SUPABASE_ANON_KEY, syncFavoritesFromDB } from './client.js?v=82';
-import { renderHome } from './views/home.js?v=82';
+import { sb, state, SUPABASE_URL, SUPABASE_ANON_KEY, syncFavoritesFromDB } from './client.js?v=83';
+import { renderHome } from './views/home.js?v=83';
 import { renderGenomes } from './views/genomes.js?v=101';
 import { renderMutants } from './views/mutants.js?v=97';
-import { renderPipeline } from './views/pipeline.js?v=82';
+import { renderPipeline } from './views/pipeline.js?v=83';
 import { renderRoadmap }  from './views/roadmap.js?v=91';
 import { renderAlignment } from './views/alignment.js?v=97';
 import { renderStructureAlignment } from './views/structure-alignment.js?v=7';

--- a/web/js/views/alignment.js
+++ b/web/js/views/alignment.js
@@ -1,5 +1,5 @@
 // ChlamAtlas — Sequence Alignment tool
-import { sb, state } from '../client.js?v=82';
+import { sb, state } from '../client.js?v=83';
 
 // ── Local state ──────────────────────────────────────────────
 let alignState = {

--- a/web/js/views/bugs.js
+++ b/web/js/views/bugs.js
@@ -1,6 +1,6 @@
 // ChlamAtlas — Bug Reports view
 
-import { sb, state } from '../client.js?v=82';
+import { sb, state } from '../client.js?v=83';
 
 export async function renderBugs(container) {
   container.innerHTML = `

--- a/web/js/views/genome-alignment.js
+++ b/web/js/views/genome-alignment.js
@@ -1,5 +1,5 @@
 // ChlamAtlas — Genome Alignment tool
-import { sb } from '../client.js?v=82';
+import { sb } from '../client.js?v=83';
 
 // ── Constants (copied from genomes.js) ───────────────────────
 const CATEGORY_COLORS = {

--- a/web/js/views/genomes.js
+++ b/web/js/views/genomes.js
@@ -1,6 +1,6 @@
 // ChlamAtlas — Genomes tab
-import { sb, state, toggleFavoriteDB } from '../client.js?v=82';
-import { isMobileViewport, onMobScroll, pushMobileDetail } from '../app.js?v=82';
+import { sb, state, toggleFavoriteDB } from '../client.js?v=83';
+import { isMobileViewport, onMobScroll, pushMobileDetail } from '../app.js?v=83';
 
 const STRAINS = [
   { id: 'CT-L2', label: '<i>C. trachomatis</i> L2/434', icon: '/design/icons_transparent/L2icon_transparent.png' },

--- a/web/js/views/home.js
+++ b/web/js/views/home.js
@@ -1,6 +1,6 @@
 // ChlamAtlas — Home tab
-import { sb, state } from '../client.js?v=82';
-import { isMobileViewport } from '../app.js?v=82';
+import { sb, state } from '../client.js?v=83';
+import { isMobileViewport } from '../app.js?v=83';
 
 const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
 

--- a/web/js/views/mutants.js
+++ b/web/js/views/mutants.js
@@ -1,6 +1,6 @@
 // ChlamAtlas — Mutants tab (full two-panel view)
-import { sb, state, toggleFavoriteDB } from '../client.js?v=82';
-import { isMobileViewport, pushMobileDetail, onMobScroll } from '../app.js?v=82';
+import { sb, state, toggleFavoriteDB } from '../client.js?v=83';
+import { isMobileViewport, pushMobileDetail, onMobScroll } from '../app.js?v=83';
 
 const COLLECTIONS = [
   { id: 'CT_L2',    label: 'C. trachomatis', icon: '/design/icons_transparent/L2icon_transparent.png' },

--- a/web/js/views/pipeline.js
+++ b/web/js/views/pipeline.js
@@ -1,5 +1,5 @@
 // ChlamAtlas — Pipeline tab (v82 rewrite)
-import { sb, state } from '../client.js?v=82';
+import { sb, state } from '../client.js?v=83';
 
 // ─────────────────────────────────────────────────────────────
 // SECTION 1: Constants, helpers, data layer (Task 4)
@@ -162,8 +162,8 @@ async function fetchData() {
 // SECTION 2: Stage strip + mutant row (Task 5)
 // ─────────────────────────────────────────────────────────────
 
-const FLAME_ON  = `<img src="/design/icons/flame-orange.png" width="15" height="15" style="display:block;object-fit:contain;" alt="Priority">`;
-const FLAME_OFF = `<img src="/design/icons/flame-off.png"    width="15" height="15" style="display:block;object-fit:contain;opacity:0.3;" alt="Not priority">`;
+const FLAME_ON  = `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#f97316" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3q1 4 4 6.5t3 5.5a1 1 0 0 1-14 0 5 5 0 0 1 1-3 1 1 0 0 0 5 0c0-2-1.5-3-1.5-5q0-2 2.5-4"/></svg>`;
+const FLAME_OFF = `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#d1d5db" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3q1 4 4 6.5t3 5.5a1 1 0 0 1-14 0 5 5 0 0 1 1-3 1 1 0 0 0 5 0c0-2-1.5-3-1.5-5q0-2 2.5-4"/></svg>`;
 const STAR_ON   = `<svg width="15" height="15" viewBox="0 0 24 24" fill="#f59e0b" stroke="#f59e0b" stroke-width="1"><polygon points="12,2 14.6,8.6 22,9.3 16.5,14.3 18.2,21.2 12,17.5 5.8,21.2 7.5,14.3 2,9.3 9.4,8.6"/></svg>`;
 const STAR_OFF  = `<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#d1d5db" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="12,2 14.6,8.6 22,9.3 16.5,14.3 18.2,21.2 12,17.5 5.8,21.2 7.5,14.3 2,9.3 9.4,8.6"/></svg>`;
 
@@ -270,13 +270,15 @@ function mutantRow(m, { showStrain = false } = {}) {
 
   return `
 <div class="${rowCls}" id="row-${esc(mutantId)}" data-mutant-id="${esc(mutantId)}" onclick="window.__plRowClick(event,'${esc(mutantId)}')">
-  <!-- Left: name + ID + type pill + strain -->
-  <div style="display:flex;align-items:center;gap:5px;flex:1;min-width:0;overflow:hidden;">
-    ${plannedChip}
-    <span style="font-size:13px;font-weight:700;color:#111;flex-shrink:0;white-space:nowrap;">${esc(displayName)}</span>
-    ${showId ? `<span style="font-size:10px;color:#9ca3af;flex-shrink:0;">${esc(showId)}</span>` : ''}
-    ${isTypedGroup ? `<span style="font-size:9px;font-weight:700;${typePillStyle}border-radius:3px;padding:1.5px 5px;flex-shrink:0;">${typeText}</span>` : ''}
-    ${showStrain ? `<span class="${strainChipCls}" style="flex-shrink:0;">${esc(sl)}</span>` : ''}
+  <!-- Left: name + type/strain on first line (name flex-shrink:0, pills may clip); ID on second line -->
+  <div style="display:flex;flex-direction:column;flex:1;min-width:0;overflow:hidden;justify-content:center;">
+    <div style="display:flex;align-items:center;gap:5px;overflow:hidden;">
+      ${plannedChip}
+      <span style="font-size:13px;font-weight:700;color:#111;flex-shrink:0;white-space:nowrap;">${esc(displayName)}</span>
+      ${isTypedGroup ? `<span style="font-size:9px;font-weight:700;${typePillStyle}border-radius:3px;padding:1.5px 5px;flex-shrink:0;">${typeText}</span>` : ''}
+      ${showStrain ? `<span class="${strainChipCls}" style="flex-shrink:0;">${esc(sl)}</span>` : ''}
+    </div>
+    ${showId ? `<span style="font-size:10px;color:#9ca3af;line-height:1.2;">${esc(showId)}</span>` : ''}
   </div>
   <!-- Middle: flame + star — instant toggles, no confirm -->
   <div style="display:flex;align-items:center;gap:2px;flex-shrink:0;margin:0 4px;" onclick="event.stopPropagation()">
@@ -832,7 +834,7 @@ function renderGroup(def) {
   return `
 <div class="mb-5" id="group-${esc(key)}">
   ${header}
-  <div style="background:white;border:1px solid #e5e7eb;border-radius:14px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.05);">
+  <div class="pl-group-card" style="background:white;border:1px solid #e5e7eb;border-radius:14px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.05);">
     <div id="group-rows-${esc(key)}">
       ${rowsHtml || '<div style="padding:16px;text-align:center;font-size:12px;color:#9ca3af;">No mutants in this group.</div>'}
     </div>
@@ -913,9 +915,9 @@ function stageKeyCard() {
   ).join('');
 
   return `
-<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;background:white;border:1px solid #e5e7eb;border-radius:10px;padding:8px 12px;margin-bottom:14px;font-size:10px;color:#6b7280;">
+<div class="pl-stage-key-card" style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;background:white;border:1px solid #e5e7eb;border-radius:10px;padding:8px 12px;margin-bottom:14px;font-size:10px;color:#6b7280;">
   <span style="font-weight:600;color:#374151;">Stage strip key:</span>
-  <span style="font-size:9px;font-weight:600;color:#374151;">Plasmid → Transform → Clone → PCR → WGS → Vitro → Vivo</span>
+  <span class="pl-stage-key-seq" style="font-size:9px;font-weight:600;color:#374151;">Plasmid → Transform → Clone → PCR → WGS → Vitro → Vivo</span>
   <span style="margin-left:auto;display:flex;gap:4px;align-items:center;flex-wrap:wrap;">${pills}</span>
 </div>`;
 }
@@ -931,8 +933,7 @@ export async function renderPipeline(container) {
 
   container.innerHTML = `
     <div style="padding:18px 0 10px;">
-      <h2 style="font-size:20px;font-weight:800;color:#111827;margin:0 0 2px;">Pipeline</h2>
-      <p style="font-size:12px;color:#9ca3af;margin:0;">Multi-lab mutant development tracker</p>
+      <h2 class="pl-pipeline-title" style="font-size:20px;font-weight:800;color:#111827;margin:0;">Pipeline</h2>
     </div>
 
     ${stageKeyCard()}

--- a/web/js/views/structure-alignment.js
+++ b/web/js/views/structure-alignment.js
@@ -1,5 +1,5 @@
 // ChlamAtlas — Structure Alignment tool
-import { sb, state } from '../client.js?v=82';
+import { sb, state } from '../client.js?v=83';
 
 // ── Constants ─────────────────────────────────────────────────
 const STRAIN_COLORS = { 'CT-L2': '#16a34a', 'CT-D': '#4b2e83', 'CM': '#2563eb' };


### PR DESCRIPTION
## Summary

- **Green header title** on mobile (pine green `#163b2b`, matching genes/mutants detail views)
- **Mutant ID on its own line** below the bold name — less cramping, ID fully visible instead of truncated inline
- **SVG flame icon** replacing PNG (Lucide flame from `design/icons_mobile`), consistent with other mobile icons
- **Remove card chrome** from group row containers on mobile — rows breathe edge-to-edge with simple dividers
- **Remove subtitle caption** ("Multi-lab mutant development tracker") under the Pipeline heading
- **Stage key card** — remove card border on mobile, hide verbose sequence text (pills still shown)
- **32×32px touch targets** for flame/star buttons on mobile
- **Right-anchor picker popup** on mobile to prevent viewport overflow
- Version bumped to v=83 for cache-busting

## Test plan

- [ ] Log in as lab member, open Pipeline tab on mobile
- [ ] Verify "Pipeline" title is dark green, no subtitle caption
- [ ] Verify mutant IDs (YW069, UWCM012, etc.) appear on a second line below the bold name
- [ ] Verify flame icon is SVG (clean stroke, not PNG)
- [ ] Verify group rows have no card border/shadow — clean flat list
- [ ] Verify stage key shows only pills (sequence text hidden on mobile)
- [ ] Expand a row — verify stage tiles and picker popup still work
- [ ] Check desktop pipeline is unchanged (cards still present on desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)